### PR TITLE
Allow saving decimal tax rates

### DIFF
--- a/src/Taxes/TaxZoneRepository.php
+++ b/src/Taxes/TaxZoneRepository.php
@@ -145,7 +145,7 @@ class TaxZoneRepository implements Contract
                                         'fields' => TaxClass::all()->map(fn ($taxClass) => [
                                             'handle' => $taxClass->handle(),
                                             'field' => [
-                                                'type' => 'integer',
+                                                'type' => 'float',
                                                 'display' => $taxClass->get('title'),
                                                 'validate' => 'min:0',
                                                 'append' => '%',

--- a/tests/Taxes/StoreTaxZonesTest.php
+++ b/tests/Taxes/StoreTaxZonesTest.php
@@ -37,7 +37,7 @@ class StoreTaxZonesTest extends TestCase
                 'countries' => ['GB'],
                 'rates' => [
                     'standard' => 20,
-                    'reduced' => 5,
+                    'reduced' => 5.5,
                 ],
             ])
             ->assertOk()
@@ -50,7 +50,7 @@ class StoreTaxZonesTest extends TestCase
         $this->assertEquals(['GB'], $taxZone->get('countries'));
         $this->assertEquals([
             'standard' => 20,
-            'reduced' => 5,
+            'reduced' => 5.5,
         ], $taxZone->get('rates'));
     }
 
@@ -67,7 +67,7 @@ class StoreTaxZonesTest extends TestCase
                 'countries' => ['GB'],
                 'rates' => [
                     'standard' => 20,
-                    'reduced' => 5,
+                    'reduced' => 5.5,
                 ],
             ])
             ->assertRedirect('/cp');
@@ -91,7 +91,7 @@ class StoreTaxZonesTest extends TestCase
                 'countries' => ['GB'],
                 'rates' => [
                     'standard' => 20,
-                    'reduced' => 5,
+                    'reduced' => 5.5,
                 ],
             ])
             ->assertSessionHasErrors('type');
@@ -116,7 +116,7 @@ class StoreTaxZonesTest extends TestCase
                 'states' => ['GLG', 'SLK'],
                 'rates' => [
                     'standard' => 20,
-                    'reduced' => 5,
+                    'reduced' => 5.5,
                 ],
             ])
             ->assertSessionHasErrors('type');
@@ -141,7 +141,7 @@ class StoreTaxZonesTest extends TestCase
                 'postcodes' => ['G*'],
                 'rates' => [
                     'standard' => 20,
-                    'reduced' => 5,
+                    'reduced' => 5.5,
                 ],
             ])
             ->assertSessionHasErrors('type');

--- a/tests/Taxes/UpdateTaxZonesTest.php
+++ b/tests/Taxes/UpdateTaxZonesTest.php
@@ -27,12 +27,13 @@ class UpdateTaxZonesTest extends TestCase
     public function can_update_tax_zone()
     {
         TaxClass::make()->handle('standard')->set('title', 'Standard')->save();
+        TaxClass::make()->handle('reduced')->set('title', 'Reduced')->save();
 
         $taxZone = tap(TaxZone::make()->handle('united-kingdom')->data([
             'title' => 'United Kingdom',
             'type' => 'countries',
             'countries' => ['GB'],
-            'rates' => ['standard' => 20],
+            'rates' => ['standard' => 20, 'reduced' => 5],
         ]))->save();
 
         $this
@@ -43,12 +44,13 @@ class UpdateTaxZonesTest extends TestCase
                 'countries' => ['GB'],
                 'rates' => [
                     'standard' => 25,
+                    'reduced' => 5.5,
                 ],
             ])
             ->assertOk();
 
         $taxZone = TaxZone::find('united-kingdom');
-        $this->assertEquals(['standard' => 25], $taxZone->get('rates'));
+        $this->assertEquals(['standard' => 25, 'reduced' => 5.5], $taxZone->get('rates'));
     }
 
     #[Test]
@@ -57,12 +59,13 @@ class UpdateTaxZonesTest extends TestCase
         Role::make('test')->addPermission('access cp')->save();
 
         TaxClass::make()->handle('standard')->set('title', 'Standard')->save();
+        TaxClass::make()->handle('reduced')->set('title', 'Reduced')->save();
 
         $taxZone = tap(TaxZone::make()->handle('united-kingdom')->data([
             'title' => 'United Kingdom',
             'type' => 'countries',
             'countries' => ['GB'],
-            'rates' => ['standard' => 20],
+            'rates' => ['standard' => 20, 'reduced' => 5],
         ]))->save();
 
         $this
@@ -73,11 +76,12 @@ class UpdateTaxZonesTest extends TestCase
                 'countries' => ['GB'],
                 'rates' => [
                     'standard' => 25,
+                    'reduced' => 5.5,
                 ],
             ])
             ->assertRedirect('/cp');
 
         $taxZone = TaxZone::find('united-kingdom');
-        $this->assertEquals(['standard' => 20], $taxZone->get('rates'));
+        $this->assertEquals(['standard' => 20, 'reduced' => 5], $taxZone->get('rates'));
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where you'd receive a validation error when trying to save a tax zone with a decimal tax rate.

We have tests to cover decimal calculations, so it looks like this was just an oversight when building out the Control Panel UI for taxes.

Fixes #40.