### PR TITLE
Only show shipping tab when order has physical products

### DIFF
--- a/src/Http/Controllers/CP/Orders/ExtractsFromOrderFields.php
+++ b/src/Http/Controllers/CP/Orders/ExtractsFromOrderFields.php
@@ -28,6 +28,7 @@ trait ExtractsFromOrderFields
 
         $extraValues = [
             'id' => $order->id(),
+            'has_physical_products' => $order->has_physical_products,
         ];
 
         return [$fields->values()->all(), $fields->meta()->all(), $extraValues];

--- a/src/Orders/Blueprint.php
+++ b/src/Orders/Blueprint.php
@@ -50,7 +50,7 @@ class Blueprint
                             'fields' => [
                                 [
                                     'handle' => 'shipping_details',
-                                    'field' => ['type' => 'shipping_details', 'hide_display' => true, 'listable' => false],
+                                    'field' => ['type' => 'shipping_details', 'hide_display' => true, 'listable' => false, 'unless' => ['has_physical_products' => false]],
                                 ],
                             ],
                         ],
@@ -59,31 +59,31 @@ class Blueprint
                             'fields' => [
                                 [
                                     'handle' => 'shipping_name',
-                                    'field' => ['type' => 'text', 'display' => __('Name'), 'listable' => false, 'width' => 50],
+                                    'field' => ['type' => 'text', 'display' => __('Name'), 'listable' => false, 'width' => 50, 'unless' => ['has_physical_products' => false]],
                                 ],
                                 [
                                     'handle' => 'shipping_line_1',
-                                    'field' => ['type' => 'text', 'display' => __('Address Line 1'), 'listable' => false, 'width' => 50],
+                                    'field' => ['type' => 'text', 'display' => __('Address Line 1'), 'listable' => false, 'width' => 50, 'unless' => ['has_physical_products' => false]],
                                 ],
                                 [
                                     'handle' => 'shipping_line_2',
-                                    'field' => ['type' => 'text', 'display' => __('Address Line 2'), 'listable' => false, 'width' => 50],
+                                    'field' => ['type' => 'text', 'display' => __('Address Line 2'), 'listable' => false, 'width' => 50, 'unless' => ['has_physical_products' => false]],
                                 ],
                                 [
                                     'handle' => 'shipping_city',
-                                    'field' => ['type' => 'text', 'display' => __('Town/City'), 'listable' => false, 'width' => 50],
+                                    'field' => ['type' => 'text', 'display' => __('Town/City'), 'listable' => false, 'width' => 50, 'unless' => ['has_physical_products' => false]],
                                 ],
                                 [
                                     'handle' => 'shipping_postcode',
-                                    'field' => ['type' => 'text', 'display' => __('Postcode'), 'listable' => false, 'width' => 50],
+                                    'field' => ['type' => 'text', 'display' => __('Postcode'), 'listable' => false, 'width' => 50, 'unless' => ['has_physical_products' => false]],
                                 ],
                                 [
                                     'handle' => 'shipping_country',
-                                    'field' => ['type' => 'dictionary', 'dictionary' => ['type' => 'countries', 'emojis' => false], 'max_items' => 1, 'display' => __('Country'), 'listable' => false, 'width' => 50],
+                                    'field' => ['type' => 'dictionary', 'dictionary' => ['type' => 'countries', 'emojis' => false], 'max_items' => 1, 'display' => __('Country'), 'listable' => false, 'width' => 50, 'unless' => ['has_physical_products' => false]],
                                 ],
                                 [
                                     'handle' => 'shipping_state',
-                                    'field' => ['type' => 'states', 'from' => 'shipping_country', 'display' => __('State/County'), 'listable' => false, 'max_items' => 1, 'width' => 50],
+                                    'field' => ['type' => 'states', 'from' => 'shipping_country', 'display' => __('State/County'), 'listable' => false, 'max_items' => 1, 'width' => 50, 'unless' => ['has_physical_products' => false]],
                                 ],
                             ],
                         ],


### PR DESCRIPTION
This pull request ensures that the "Shipping" tab on the order details page is only shown when the order includes physical products.

Related: https://github.com/duncanmcclean/statamic-cargo/discussions/51