### PR TITLE
Rename `public/checkout` directory

### DIFF
--- a/docs/frontend/checkout/prebuilt.md
+++ b/docs/frontend/checkout/prebuilt.md
@@ -142,4 +142,4 @@ Finally, update the `checkout/layout.antlers.html` file to reference your own st
 {{ vite src="resources/css/site.css" }} {{# [tl! add] #}}
 ```
 
-To stay organised, you may now delete the `public/checkout` directory.
+To stay organised, you may now delete the `public/checkout-build` directory.

--- a/resources/views/checkout/layout.antlers.html
+++ b/resources/views/checkout/layout.antlers.html
@@ -16,7 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title }} - {{ site:name }}</title>
     {{ stack:header_scripts }}
-    {{ vite directory="checkout" hot="checkout" src="resources/css/checkout.css" }}
+    {{ vite directory="checkout-build" hot="checkout" src="resources/css/checkout.css" }}
     <style>[x-cloak] { display: none !important; }</style>
     <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 </head>

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -71,7 +71,7 @@ class ServiceProvider extends AddonServiceProvider
         ], 'cargo-config');
 
         $this->publishes([
-            __DIR__.'/../resources/dist-checkout/build' => public_path('checkout'),
+            __DIR__.'/../resources/dist-checkout/build' => public_path('checkout-build'),
             __DIR__.'/../resources/views/checkout' => resource_path('views/checkout'),
         ], 'cargo-prebuilt-checkout');
 


### PR DESCRIPTION
This pull request renames the `public/checkout` directory to `public/checkout-build` to avoid potential conflicts with Apache, where `/checkout` would return a Forbidden error page because a directory exists with the same name.

Related: https://github.com/duncanmcclean/statamic-cargo/discussions/54