### PR TITLE
Return `site` when augmenting carts & orders

### DIFF
--- a/src/Cart/AugmentedCart.php
+++ b/src/Cart/AugmentedCart.php
@@ -37,6 +37,7 @@ class AugmentedCart extends AbstractAugmented
     {
         return [
             'id',
+            'site',
             'is_free',
             'customer',
             'discounts',

--- a/src/Orders/AugmentedOrder.php
+++ b/src/Orders/AugmentedOrder.php
@@ -34,6 +34,7 @@ class AugmentedOrder extends AugmentedCart
             'order_number',
             'date',
             'status',
+            'site',
             'is_free',
             'customer',
             'discounts',
@@ -44,7 +45,6 @@ class AugmentedOrder extends AugmentedCart
             'has_physical_products',
             'has_digital_products',
             'downloads',
-            'site',
         ];
     }
 


### PR DESCRIPTION
This pull request ensures that `site` is returned when augmenting carts & orders.