### PR TITLE
Fix TailwindCSS not being generated in `cp.css`

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,12 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import statamic from '@statamic/cms/vite-plugin';
+import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
     plugins: [
         statamic(),
+        tailwindcss(),
         laravel({
             hotFile: 'resources/dist/hot',
             publicDirectory: 'resources/dist',


### PR DESCRIPTION
This pull request fixes an issue where TailwindCSS classes weren't being generated in `cp.css` due to a missing Vite plugin.