### PR TITLE
Simplify tax rates fieldtype

### DIFF
--- a/src/Fieldtypes/TaxRates.php
+++ b/src/Fieldtypes/TaxRates.php
@@ -4,26 +4,13 @@ namespace DuncanMcClean\Cargo\Fieldtypes;
 
 use DuncanMcClean\Cargo\Facades\TaxClass;
 use Statamic\Fields\Fields;
-use Statamic\Fields\Fieldtype;
-use Statamic\Support\Arr;
+use Statamic\Fieldtypes\Group as GroupFieldtype;
 
-class TaxRates extends Fieldtype
+class TaxRates extends GroupFieldtype
 {
     protected $selectable = false;
 
-    public function process($data)
-    {
-        $values = $this->fields()->addValues($data ?? [])->process()->values()->all();
-
-        return Arr::removeNullValues($values);
-    }
-
-    public function preProcess($data)
-    {
-        return $this->fields()->addValues($data ?? [])->preProcess()->values()->all();
-    }
-
-    private function fields(): Fields
+    public function fields(): Fields
     {
         $fields = TaxClass::all()->map(fn ($taxClass) => [
             'handle' => $taxClass->handle(),
@@ -39,58 +26,11 @@ class TaxRates extends Fieldtype
         return new Fields($fields, $this->field()->parent(), $this->field());
     }
 
-    public function rules(): array
-    {
-        return ['array'];
-    }
-
-    public function extraRules(): array
-    {
-        $rules = $this
-            ->fields()
-            ->addValues((array) $this->field->value())
-            ->validator()
-            ->withContext([
-                'prefix' => $this->field->validationContext('prefix'),
-            ])
-            ->rules();
-
-        return collect($rules)->mapWithKeys(function ($rules, $handle) {
-            return [$this->field->handle().'.'.$handle => $rules];
-        })->all();
-    }
-
-    public function extraValidationAttributes(): array
-    {
-        return collect($this->fields()->validator()->attributes())->mapWithKeys(function ($attribute, $handle) {
-            return [$this->field->handle().'.'.$handle => $attribute];
-        })->all();
-    }
-
     public function preload()
     {
         return [
             'fields' => $this->fields()->all(),
             'meta' => $this->fields()->addValues($this->field->value() ?? $this->defaultGroupData())->meta()->toArray(),
         ];
-    }
-
-    protected function defaultGroupData()
-    {
-        return $this->fields()->all()->map(function ($field) {
-            return $field->fieldtype()->preProcess($field->defaultValue());
-        })->all();
-    }
-
-    public function preProcessValidatable($value)
-    {
-        return array_merge(
-            $value ?? [],
-            $this->fields()
-                ->addValues($value ?? [])
-                ->preProcessValidatables()
-                ->values()
-                ->all(),
-        );
     }
 }


### PR DESCRIPTION
This pull request simplifies the Tax Rates fieldtype introduced in #61, by extending the Group fieldtype class for most of the preProcess/process/validation logic.

The only thing that really differs between them is the Vue component and where the fields come from.