### PR TITLE
Drop axios dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
         "@tailwindcss/typography": "^0.5.13",
         "@tailwindcss/vite": "^4.1.8",
         "autoprefixer": "^10.4.20",
-        "axios": "^1.11.0",
         "postcss": "^8.4.41",
         "postcss-import": "^16.1.0",
         "tailwindcss": "^4.1.8"

--- a/resources/js/components/fieldtypes/CustomersFieldtype.vue
+++ b/resources/js/components/fieldtypes/CustomersFieldtype.vue
@@ -1,9 +1,11 @@
 <script setup>
-import axios from 'axios';
 import { Fieldtype, requireElevatedSession } from '@statamic/cms';
 import { InlineEditForm } from '@statamic/cms/temporary';
 import { Dropdown, DropdownMenu, DropdownItem, Heading, Description, Badge, injectPublishContext } from '@statamic/cms/ui';
-import { computed, ref } from 'vue';
+import { getCurrentInstance, computed, ref } from 'vue';
+
+const instance = getCurrentInstance();
+const { $axios } = instance.appContext.config.globalProperties;
 
 const { values, parentContainer: initialParentContainer } = injectPublishContext();
 
@@ -51,7 +53,7 @@ function itemUpdated(responseData) {
 }
 
 function convertToUser() {
-    axios
+    $axios
         .post(props.meta.convertGuestToUserUrl, {
             email: props.value.email,
             order_id: values.value.id,


### PR DESCRIPTION
This pull request drops our dependency on `axios`, relying on the Axios instance provided by Statamic.