### PR TITLE
Allow using route bindings on frontend

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -245,7 +245,7 @@ class ServiceProvider extends AddonServiceProvider
     {
         Route::bind('discount', function ($handle, $route = null) {
             if (! $route || (! $this->isCpRoute($route) && ! $this->isFrontendBindingEnabled())) {
-                return false;
+                return $handle;
             }
 
             $field = $route->bindingFieldFor('discount') ?? 'handle';
@@ -257,7 +257,7 @@ class ServiceProvider extends AddonServiceProvider
 
         Route::bind('order', function ($id, $route = null) {
             if (! $route || (! $this->isCpRoute($route) && ! $this->isFrontendBindingEnabled())) {
-                return false;
+                return $handle;
             }
 
             $field = $route->bindingFieldFor('order') ?? 'id';
@@ -269,7 +269,7 @@ class ServiceProvider extends AddonServiceProvider
 
         Route::bind('tax-class', function ($handle, $route = null) {
             if (! $route || (! $this->isCpRoute($route) && ! $this->isFrontendBindingEnabled())) {
-                return false;
+                return $handle;
             }
 
             return TaxClass::find($handle);
@@ -277,7 +277,7 @@ class ServiceProvider extends AddonServiceProvider
 
         Route::bind('tax-zone', function ($handle, $route = null) {
             if (! $route || (! $this->isCpRoute($route) && ! $this->isFrontendBindingEnabled())) {
-                return false;
+                return $handle;
             }
 
             return TaxZone::find($handle);


### PR DESCRIPTION
## Frontend routes

Statamic (and by extension, Cargo) only registers route bindings on non-CP routes to avoid potential conflicts with existing apps.

If you know there aren't going to be any conflicts, you may override the behaviour in the `routes.php` config file:

```php
// config/statamic/routes.php

'bindings' => true,
```

This pull request ensures that Cargo takes the `bindings` config option into account when registering route bindings, mirroring Statamic.

## Unable to use `{order}` in frontend route

This pull request also fixes an issue when trying to use `{order}` in a frontend route, where Cargo would return `false` instead of returning the value from the URL.

Fixes #70