### PR TITLE
Fix tax rates fieldtype

### DIFF
--- a/src/Fieldtypes/TaxRates.php
+++ b/src/Fieldtypes/TaxRates.php
@@ -29,7 +29,7 @@ class TaxRates extends GroupFieldtype
     public function preload()
     {
         return [
-            'fields' => $this->fields()->all(),
+            'fields' => $this->fields()->toPublishArray(),
             'meta' => $this->fields()->addValues($this->field->value() ?? $this->defaultGroupData())->meta()->toArray(),
         ];
     }


### PR DESCRIPTION
This pull request fixes an issue on the Tax Zone create/edit pages, where a console error would be thrown due to a lack of `fields` being provided by the backend.