### PR TITLE
Reset discount total on line items when recalculating

### DIFF
--- a/src/Cart/Calculator/ResetTotals.php
+++ b/src/Cart/Calculator/ResetTotals.php
@@ -23,6 +23,7 @@ class ResetTotals
             $lineItem->unitPrice(0);
             $lineItem->taxTotal(0);
             $lineItem->subTotal(0);
+            $lineItem->discountTotal(0);
             $lineItem->total(0);
 
             $lineItem->remove('tax_breakdown');


### PR DESCRIPTION
This pull request fixes an issue where the discount total wouldn't be reset on line items when recalculating the cart, leading to issues where the discount doubles every time.