### PR TITLE
Pre-built checkout: Re-fetch payment gateway data when grand total changes

### DIFF
--- a/resources/views/checkout/steps/_payment.antlers.html
+++ b/resources/views/checkout/steps/_payment.antlers.html
@@ -54,6 +54,11 @@
                     this.fetchPaymentGateways();
 
                     this.selectedPaymentGateway = this.cart.payment_gateway;
+
+                    this.$watch('cart.grand_total', () => {
+                        this.isFetchingPaymentGateways = true;
+                        this.fetchPaymentGateways();
+                    });
                 },
 
                 fetchPaymentGateways() {


### PR DESCRIPTION
This pull request ensures that payment gateway data is re-fetched when the grand total changed, fixing an issue where applying a discount whilst on the "Payment" step wouldn't affect the amount "charged" to the customer.

The customer would eventually pay the correct amount once the payment is captured, but until then the full amount would show on their bank statement.