### PR TITLE
Add Ghanaian Cedi to currencies in `cargo:install` command

### DIFF
--- a/src/Data/Currencies.php
+++ b/src/Data/Currencies.php
@@ -39,6 +39,7 @@ class Currencies
         ['code' => 'FKP', 'name' => 'Falkland Islands Pound', 'symbol' => '£'],
         ['code' => 'GBP', 'name' => 'Pound Sterling', 'symbol' => '£'],
         ['code' => 'GIP', 'name' => 'Gibraltar Pound', 'symbol' => '£'],
+        ['code' => 'GHS', 'name' => 'Ghanaian Cedi', 'symbol' => '₵'],
         ['code' => 'GTQ', 'name' => 'Quetzal', 'symbol' => 'Q'],
         ['code' => 'GYD', 'name' => 'Guyana Dollar', 'symbol' => '$'],
         ['code' => 'HKD', 'name' => 'Hong Kong Dollar', 'symbol' => '$'],


### PR DESCRIPTION
This pull request adds "Ghanaian Cedi" to the currency options in the `cargo:install` command.