### PR TITLE
Remove Bulgarian Lev from Currencies array

### DIFF
--- a/src/Data/Currencies.php
+++ b/src/Data/Currencies.php
@@ -14,7 +14,6 @@ class Currencies
         ['code' => 'AZN', 'name' => 'Azerbaijanian Manat', 'symbol' => 'ман'],
         ['code' => 'BAM', 'name' => 'Convertible Marks', 'symbol' => 'KM'],
         ['code' => 'BBD', 'name' => 'Barbados Dollar', 'symbol' => '$'],
-        ['code' => 'BGN', 'name' => 'Bulgarian Lev', 'symbol' => 'лв'],
         ['code' => 'BMD', 'name' => 'Bermudian Dollar', 'symbol' => '$'],
         ['code' => 'BND', 'name' => 'Brunei Dollar', 'symbol' => '$'],
         ['code' => 'BOB', 'name' => 'BOV Boliviano Mvdol', 'symbol' => '$b'],


### PR DESCRIPTION
This pull request removes the Bulgarian Lev (BGN) from the Currencies array referenced during the `cargo:install` command as it is being replaced by the Euro.

BGN is [currently in a "double circulation" period](https://en.wikipedia.org/wiki/Bulgarian_lev#) with the Euro from the 1st January to the 31st January.