### PR TITLE
Make `line_item_tax_total` available in templates

### DIFF
--- a/docs/frontend/tags/cart.md
+++ b/docs/frontend/tags/cart.md
@@ -57,6 +57,8 @@ These snippets might come in handy... they're all pretty self-explanatory:
 * `{{ cart:sub_total }}`
 * `{{ cart:discount_total }}`
 * `{{ cart:tax_total }}`
+* `{{ cart:line_item_tax_total }}`
+* `{{ cart:shipping_tax_total }}`
 * `{{ cart:shipping_total }}`
 * `{{ cart:is_free }}`
 * `{{ cart:has_physical_products }}`

--- a/src/Cart/AugmentedCart.php
+++ b/src/Cart/AugmentedCart.php
@@ -7,6 +7,7 @@ use DuncanMcClean\Cargo\Fieldtypes\Money;
 use DuncanMcClean\Cargo\Orders\LineItem;
 use Statamic\Data\AbstractAugmented;
 use Statamic\Fields\Field;
+use Statamic\Fields\Value;
 
 class AugmentedCart extends AbstractAugmented
 {
@@ -47,6 +48,7 @@ class AugmentedCart extends AbstractAugmented
             'tax_breakdown',
             'has_physical_products',
             'has_digital_products',
+            'line_items_tax_total',
         ];
     }
 
@@ -125,5 +127,19 @@ class AugmentedCart extends AbstractAugmented
         return $this->data->lineItems()
             ->filter(fn (LineItem $lineItem) => $lineItem->product()?->get('type', 'physical') === 'digital')
             ->isNotEmpty();
+    }
+
+    public function lineItemsTaxTotal()
+    {
+        $moneyField = new Field('line_items_tax_total', [
+            'type' => 'money',
+            'save_zero_value' => true,
+        ]);
+
+        return new Value(
+            value: $this->data->lineItems()->sum('taxTotal'),
+            fieldtype: $moneyField->fieldtype(),
+            augmentable: $this->data
+        );
     }
 }

--- a/src/Orders/AugmentedOrder.php
+++ b/src/Orders/AugmentedOrder.php
@@ -44,6 +44,7 @@ class AugmentedOrder extends AugmentedCart
             'tax_breakdown',
             'has_physical_products',
             'has_digital_products',
+            'line_items_tax_total',
             'downloads',
         ];
     }


### PR DESCRIPTION
This pull request makes `line_item_tax_total` available in templates (or anywhere you have an augmented cart/order).

The `shipping_tax_total` is persisted in the cart/order data, however the `line_item_tax_total` is calculated by summing each line item's `tax_total`.