### PR TITLE
Add `generating-order-number` hook

### DIFF
--- a/docs/docs/orders.md
+++ b/docs/docs/orders.md
@@ -143,6 +143,23 @@ When an order is created, Cargo will generate a unique order number. By default,
 'minimum_order_number' => 5000,
 ```
 
+You may hook into the Stache `OrderRepository` class to customize how order numbers are generated:
+
+```php
+// app/Providers/AppServiceProvider.php
+
+use DuncanMcClean\Cargo\Stache\Repositories\OrderRepository;
+
+OrderRepository::hook('generating-order-number', function ($payload, $next) {
+    // $payload->order;
+    // $payload->orderNumber;
+    
+    $payload->orderNumber = 5000;
+    
+    return $next($payload);
+});
+```
+
 :::tip note
 When storing orders in the database, the `order_number` column is auto-incrementing, meaning the database (eg. MySQL, PostgreSQL, etc) is in charge of generating the next order number.
 

--- a/tests/Stache/Repositories/OrderRepositoryTest.php
+++ b/tests/Stache/Repositories/OrderRepositoryTest.php
@@ -161,6 +161,22 @@ class OrderRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function can_hook_into_generating_order_number()
+    {
+        $this->repo->hook('generating-order-number', function ($payload, $next) {
+            $payload->orderNumber = 5000;
+
+            return $next($payload);
+        });
+
+        $order = Order::make();
+
+        $this->repo->save($order);
+
+        $this->assertEquals(5000, $order->orderNumber());
+    }
+
+    #[Test]
     public function can_delete_an_order()
     {
         $order = Order::make()


### PR DESCRIPTION
This pull request adds a `generating-order-number` [hook](https://v6.statamic.dev/backend-apis/hooks) to the Stache `OrderRepository` class, allowing you to customise how order numbers are generated:

```php
// app/Providers/AppServiceProvider.php

use DuncanMcClean\Cargo\Stache\Repositories\OrderRepository;

OrderRepository::hook('generating-order-number', function ($payload, $next) {
    // $payload->order;
    // $payload->orderNumber;

    $payload->orderNumber = 5000;

    return $next($payload);
});
```

This PR also adds missing documentation for the `minimum_order_number` config option and how to customise order number generation when storing orders in the database.