### PR TITLE
Calculate subtotal right after calculating line items

### DIFF
--- a/src/Cart/Calculator/CalculateLineItems.php
+++ b/src/Cart/Calculator/CalculateLineItems.php
@@ -12,7 +12,7 @@ class CalculateLineItems
 
     public function handle(Cart $cart, Closure $next)
     {
-        $cart->lineItems()->map(function (LineItem $lineItem) use ($cart) {
+        $cart->lineItems()->each(function (LineItem $lineItem) use ($cart) {
             $product = $lineItem->product();
 
             $price = match (true) {
@@ -24,9 +24,9 @@ class CalculateLineItems
             $lineItem->unitPrice($price);
             $lineItem->subTotal($price * $lineItem->quantity());
             $lineItem->total($lineItem->subTotal());
-
-            return $lineItem;
         });
+
+        $cart->subTotal($cart->lineItems()->map->subTotal()->sum());
 
         return $next($cart);
     }

--- a/src/Cart/Calculator/CalculateTotals.php
+++ b/src/Cart/Calculator/CalculateTotals.php
@@ -11,9 +11,6 @@ class CalculateTotals
     {
         $pricesIncludeTax = config('statamic.cargo.taxes.price_includes_tax');
 
-        // Calculate the subtotal by summing the line item subtotals (totals without additional taxes)
-        $cart->subTotal($cart->lineItems()->map->subTotal()->sum());
-
         // Calculate the total (subtotal + taxes if they aren't included in the prices)
         $total = $cart->subTotal();
 

--- a/tests/Cart/Calculator/CalculateLineItemsTest.php
+++ b/tests/Cart/Calculator/CalculateLineItemsTest.php
@@ -94,6 +94,23 @@ class CalculateLineItemsTest extends TestCase
     }
 
     #[Test]
+    public function calculates_order_subtotal()
+    {
+        Collection::make('products')->save();
+        $productA = tap(Entry::make()->collection('products')->data(['price' => 2550]))->save();
+        $productB = tap(Entry::make()->collection('products')->data(['price' => 1500]))->save();
+
+        $cart = Cart::make()->lineItems([
+            ['id' => 'a', 'product' => $productA->id(), 'quantity' => 2],
+            ['id' => 'b', 'product' => $productB->id(), 'quantity' => 1],
+        ]);
+
+        (new CalculateLineItems)->handle($cart, fn ($cart) => $cart);
+
+        $this->assertEquals(6600, $cart->subTotal());
+    }
+
+    #[Test]
     public function total_can_be_calculated_correctly_using_price_hook()
     {
         Collection::make('products')->save();


### PR DESCRIPTION
This pull request moves the calculation of the subtotal to right after calculating line item totals, ensuring its available in custom tax drivers & shipping methods.

Previously, it was one of the last calculations to be done.

Fixes #113