### PR TITLE
Fix productVariants method to handle null values

### DIFF
--- a/src/Products/Productable.php
+++ b/src/Products/Productable.php
@@ -37,7 +37,7 @@ trait Productable
 
     public function productVariants(): array
     {
-        return $this->value('product_variants', []);
+        return $this->value('product_variants') ?? [];
     }
 
     public function stock(): ?int


### PR DESCRIPTION
For some reason, I got "DuncanMcClean\\Cargo\\Products\\Product::productVariants(): Return value must be of type array, null returned" with some products but not all. This way, all products are working.