### PR TITLE
Fix PSR-4 autoloading warning from `AddressTest`

### DIFF
--- a/tests/Data/AddressTest.php
+++ b/tests/Data/AddressTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Data;
+namespace Tests\Data;
 
 use DuncanMcClean\Cargo\Data\Address;
 use PHPUnit\Framework\Attributes\Test;


### PR DESCRIPTION
This pull request fixes the PSR-4 autoloading warning from the `AddressTest` when running `composer dump-autoload`:

```
Class Data\AddressTest located in ./tests/Data/AddressTest.php does not comply with psr-4 autoloading standard (rule: Tests\ => ./tests). Skipping.
```