### PR TITLE
Handle tax classes & tax zones with numerical handles

### DIFF
--- a/src/Taxes/TaxClassRepository.php
+++ b/src/Taxes/TaxClassRepository.php
@@ -20,7 +20,7 @@ class TaxClassRepository implements Contract
         $parse = YAML::file($this->getPath())->parse();
 
         return collect($parse)->map(function ($taxClass, $handle) {
-            return $this->make()->handle($handle)->data($taxClass);
+            return $this->make()->handle((string) $handle)->data($taxClass);
         });
     }
 

--- a/src/Taxes/TaxZone.php
+++ b/src/Taxes/TaxZone.php
@@ -37,7 +37,9 @@ class TaxZone implements Augmentable, Contract
 
     public function rates(): Collection
     {
-        return collect($this->get('rates'))->reject(fn ($rate) => is_null($rate));
+        return collect($this->get('rates'))
+            ->mapWithKeys(fn ($rate, $handle) => [(string) $handle => $rate])
+            ->reject(fn ($rate) => is_null($rate));
     }
 
     public function save(): bool

--- a/src/Taxes/TaxZoneRepository.php
+++ b/src/Taxes/TaxZoneRepository.php
@@ -21,7 +21,7 @@ class TaxZoneRepository implements Contract
         $parse = YAML::file($this->getPath())->parse();
 
         return collect($parse)->map(function ($taxZone, $handle) {
-            return $this->make()->handle($handle)->data($taxZone);
+            return $this->make()->handle((string) $handle)->data($taxZone);
         });
     }
 

--- a/tests/Taxes/TaxClassTest.php
+++ b/tests/Taxes/TaxClassTest.php
@@ -102,4 +102,44 @@ class TaxClassTest extends TestCase
             'reduced' => ['title' => 'Reduced Tax'],
         ], YAML::file($this->path)->parse());
     }
+
+    #[Test]
+    public function it_handles_tax_classes_with_numerical_handles_correctly()
+    {
+        // Create tax class with numerical value
+        $taxClass = Facades\TaxClass::make()
+            ->handle('21')
+            ->data(['title' => '21% Tax']);
+
+        $taxClass->save();
+
+        $this->assertEquals([
+            21 => ['title' => '21% Tax'],
+        ], YAML::file($this->path)->parse());
+
+        // Find tax class by its handle
+        $find = Facades\TaxClass::find('21');
+
+        $this->assertInstanceOf(TaxClass::class, $find);
+        $this->assertSame('21', $find->handle());
+        $this->assertEquals('21% Tax', $find->get('title'));
+
+        // Verify it appears in all()
+        $all = Facades\TaxClass::all();
+
+        $this->assertEquals(1, $all->count());
+        $this->assertSame('21', $all->first()->handle());
+
+        // Update the tax class
+        $find->set('title', '21% VAT')->save();
+
+        $this->assertEquals([
+            21 => ['title' => '21% VAT'],
+        ], YAML::file($this->path)->parse());
+
+        // Delete the tax class
+        $find->delete();
+
+        $this->assertEquals([], YAML::file($this->path)->parse());
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue where tax classes and tax zones couldn't be created with purely numerical numbers. 

Fixes #127
