### PR TITLE
Dedicated docs page for widgets

### DIFF
--- a/docs/docs/orders.md
+++ b/docs/docs/orders.md
@@ -102,37 +102,6 @@ class RoyalMailPackageDeliveredListener
 }
 ```
 
-## Widgets
-Cargo includes a few helpful [widgets](https://statamic.dev/widgets/overview) out-of-the-box for things like Total Revenue, New Customers, etc.
-
-Cargo may have already configured widgets during the install process, but you can add and configure them yourself in the `config/statamic/cp.php` file:
-
-```php
-// config/statamic/cp.php
-
-'widgets' => [
-    ['type' => 'total_sales', 'width' => 25],
-    ['type' => 'total_revenue', 'width' => 25],
-    ['type' => 'new_customers', 'width' => 25],
-    ['type' => 'returning_customers', 'width' => 25],
-    ['type' => 'refunded_orders', 'width' => 25],
-    ['type' => 'recent_orders', 'width' => 50, 'limit' => 10],
-    ['type' => 'low_stock_products', 'width' => 50, 'limit' => 5],
-],
-```
-
-### Options
-
-You may provide a `days` option to customise the comparison period for statistic widgets. Defaults to `30`.
-```php
-['type' => 'total_revenue', 'width' => 25, 'days' => 14],
-```
-
-You may provide a `limit` option to control the number of items displayed in listing widgets. Defaults to `5`.
-```php
-['type' => 'recent_orders', 'width' => 50, 'limit' => 10],
-```
-
 ## Order Numbers
 
 When an order is created, Cargo will generate a unique order number. By default, order numbers start at `1000` but the minimum value is configurable:

--- a/docs/docs/widgets.md
+++ b/docs/docs/widgets.md
@@ -1,0 +1,33 @@
+---
+title: Widgets
+description: "Cargo includes several helpful widgets for your Control Panel dashboard, including Total Revenue, New Customers, and more."
+---
+Cargo includes a few helpful [widgets](https://statamic.dev/widgets/overview) out-of-the-box for things like Total Revenue, New Customers, etc.
+
+Cargo may have already configured widgets during the install process, but you can add and configure them yourself in the `config/statamic/cp.php` file:
+
+```php
+// config/statamic/cp.php
+
+'widgets' => [
+    ['type' => 'total_sales', 'width' => 25],
+    ['type' => 'total_revenue', 'width' => 25],
+    ['type' => 'new_customers', 'width' => 25],
+    ['type' => 'returning_customers', 'width' => 25],
+    ['type' => 'refunded_orders', 'width' => 25],
+    ['type' => 'recent_orders', 'width' => 50, 'limit' => 10],
+    ['type' => 'low_stock_products', 'width' => 50, 'limit' => 5],
+],
+```
+
+## Options
+
+You may provide a `days` option to customise the comparison period for statistic widgets. Defaults to `30`.
+```php
+['type' => 'total_revenue', 'width' => 25, 'days' => 14],
+```
+
+You may provide a `limit` option to control the number of items displayed in listing widgets. Defaults to `5`.
+```php
+['type' => 'recent_orders', 'width' => 50, 'limit' => 10],
+```


### PR DESCRIPTION
This pull request moves the widget docs into a dedicated page because having them on the "Orders" page doesn't make much sense if there are customer/product-related widgets.