### PR TITLE
Fix error migrating status log entries from the database

### DIFF
--- a/src/Commands/Migration/MigrateOrders.php
+++ b/src/Commands/Migration/MigrateOrders.php
@@ -184,7 +184,11 @@ class MigrateOrders extends Command
                         'items' => Json::decode($row->items),
                         'gateway' => Json::decode($row->gateway),
                         'site' => Site::default()->handle(),
-                        'status_log' => $statusLogs->where('order_id', $row->id)->toArray(),
+                        'status_log' => $statusLogs
+                            ->where('order_id', $row->id)
+                            ->map(fn ($item) => (array) $item)
+                            ->values()
+                            ->all(),
                     ]);
 
                 $this->createOrderFromData($data)->saveQuietly();


### PR DESCRIPTION
This pull request fixes an error when migrating status log entries from the database. 

Individual rows were `stdClass` objects, rather than arrays, expected by the `MapsTimelineEvents::mapTimelineEvents()` method. This PR casts the objects to arrays before migrating an order.

Fixes #133
