### PR TITLE
Add "Cancellation Reason" input to order details

### DIFF
--- a/resources/js/components/orders/OrderStatus.vue
+++ b/resources/js/components/orders/OrderStatus.vue
@@ -1,28 +1,28 @@
 <script setup>
-import { computed, ref, onMounted } from 'vue';
-import { Badge, Button, Field, Select, Input, Description } from '@statamic/cms/ui';
+import { ref, onMounted } from 'vue';
+import { Button, Field, Select, Input, Description, Textarea } from '@statamic/cms/ui';
 import OrderStatusBadge from "./OrderStatusBadge.vue";
 
-const emit = defineEmits(['update:modelValue', 'update:trackingNumber']);
+const emit = defineEmits(['update:modelValue', 'update:trackingNumber', 'update:cancellationReason']);
 
 const props = defineProps({
     orderId: String,
     statuses: Array,
     packingSlipUrl: String,
     modelValue: String,
-    trackingNumber: {
-        type: String,
-        default: null,
-    },
+    trackingNumber: { type: String, required: false },
+    cancellationReason: { type: String, required: false },
 });
 
 const status = ref(props.modelValue);
 const trackingNumber = ref(props.trackingNumber);
+const cancellationReason = ref(props.cancellationReason);
 const updating = ref(false);
 
 function update() {
     emit('update:modelValue', status.value);
     emit('update:trackingNumber', trackingNumber.value);
+    emit('update:cancellationReason', cancellationReason.value);
     updating.value = false;
 }
 
@@ -37,17 +37,15 @@ onMounted(() => {
 </script>
 
 <template>
-    <div v-if="!updating">
+    <div v-if="!updating" class="flex flex-col gap-y-4">
         <div class="flex items-center justify-between">
 	        <OrderStatusBadge :status="status" size="lg" />
             <Button :text="__('Change')" size="sm" @click="updating = true" />
         </div>
 
-        <Description
-            v-if="trackingNumber"
-            class="mt-2"
-            :text="__('Tracking Number: :trackingNumber', { trackingNumber })"
-        />
+        <Description v-if="trackingNumber" :text="__('Tracking Number: :trackingNumber', { trackingNumber })" />
+
+        <Description v-if="cancellationReason" :text="__('Cancellation Reason: :cancellationReason', { cancellationReason })" />
     </div>
 
     <div v-else class="flex flex-col space-y-6">
@@ -55,8 +53,12 @@ onMounted(() => {
             <Select class="w-full" :options="statuses" v-model:modelValue="status" />
         </Field>
 
-        <Field v-if="status === 'shipped'" label="Tracking Number">
+        <Field v-if="status === 'shipped'" :label="__('Tracking Number')">
             <Input v-model:modelValue="trackingNumber" />
+        </Field>
+
+        <Field v-if="status === 'cancelled'" :label="__('Cancellation Reason')">
+            <Textarea v-model:modelValue="cancellationReason" />
         </Field>
 
         <div v-if="status === 'returned' || status === 'cancelled'">

--- a/resources/js/components/orders/PublishForm.vue
+++ b/resources/js/components/orders/PublishForm.vue
@@ -150,8 +150,10 @@ function actionCompleted(successful = null, response) {
                             :packing-slip-url="actions.packingSlip"
                             :model-value="values.status"
                             :tracking-number="values.tracking_number"
+                            :cancellation-reason="values.cancellation_reason"
                             @update:modelValue="values.status = $event"
                             @update:trackingNumber="values.tracking_number = $event"
+                            @update:cancellationReason="values.cancellation_reason = $event"
                         />
                     </Card>
                 </Panel>

--- a/src/Orders/Blueprint.php
+++ b/src/Orders/Blueprint.php
@@ -149,6 +149,10 @@ class Blueprint
                                     'handle' => 'tracking_number',
                                     'field' => ['type' => 'text', 'display' => __('Tracking Number'), 'visibility' => 'hidden', 'listable' => 'hidden'],
                                 ],
+                                [
+                                    'handle' => 'cancellation_reason',
+                                    'field' => ['type' => 'text', 'display' => __('Cancellation Reason'), 'visibility' => 'hidden', 'listable' => 'hidden'],
+                                ],
                             ],
                         ],
                     ],


### PR DESCRIPTION
This pull request adds a "Cancellation Reason" input to the order details page, making it easy for store managers to note why an order was cancelled.

<img width="345" height="482" alt="CleanShot 2026-02-17 at 19 41 25" src="https://github.com/user-attachments/assets/90417a41-e9f3-475d-993d-b1977f8a8242" />

<img width="343" height="198" alt="CleanShot 2026-02-17 at 19 41 48" src="https://github.com/user-attachments/assets/56b59e8b-159b-46f9-a64d-2fdc46c0d119" />
