### PR TITLE
Fix error caused by deleted discount

### DIFF
--- a/src/Discounts/Actions/UpdateDiscounts.php
+++ b/src/Discounts/Actions/UpdateDiscounts.php
@@ -12,7 +12,7 @@ class UpdateDiscounts
     {
         collect($order->get('discount_breakdown'))->each(function ($discount) use ($order) {
             $discount = Discount::find($discount['discount']);
-            $discount->set('redemptions_count', $discount->get('redemptions_count', 0) + 1)->saveQuietly();
+            $discount?->set('redemptions_count', $discount->get('redemptions_count', 0) + 1)->saveQuietly();
 
             DiscountRedeemed::dispatch($discount, $order);
         });


### PR DESCRIPTION
This pull request fixes an error during checkout when the discount associated with the order has been deleted.