### PR TITLE
Supports Laravel 13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,13 +16,13 @@ jobs:
     strategy:
       matrix:
         php: [8.3, 8.4, 8.5]
-        laravel: [12.*]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
           - os: windows-latest
             php: 8.5
-            laravel: 12.*
+            laravel: 13.*
             stability: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
@@ -92,7 +92,7 @@ jobs:
         run: vendor/bin/phpunit --group=payments
         if: steps.should-run-tests.outputs.result == 'true' 
           && steps.should-run-payment-tests.outputs.result == 'true' 
-          && matrix.php == 8.5 && matrix.laravel == '12.*' 
+          && matrix.php == 8.5 && matrix.laravel == '13.*' 
           && matrix.stability == 'prefer-stable'
         env:
           STRIPE_KEY: ${{ secrets.STRIPE_KEY }}

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "mollie/mollie-api-php": "^3.0",
         "moneyphp/money": "^4.5",
         "pixelfear/composer-dist-plugin": "^0.1.0",
-        "statamic/cms": "^6.0",
+        "statamic/cms": "^6.5",
         "stillat/proteus": "^4.0",
         "stripe/stripe-php": "^16.4",
         "ext-zip": "*"

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require": {
         "php": "^8.3",
         "ext-intl": "*",
-        "laravel/framework": "^11.0 || ^12.0",
+        "laravel/framework": "^12.0 || ^13.0",
         "mollie/mollie-api-php": "^3.0",
         "moneyphp/money": "^4.5",
         "pixelfear/composer-dist-plugin": "^0.1.0",
@@ -53,8 +53,8 @@
     },
     "require-dev": {
         "laravel/pint": "^1.18",
-        "orchestra/testbench": "^10.0",
-        "phpunit/phpunit": "^11.0",
+        "orchestra/testbench": "^10.0 || ^11.0",
+        "phpunit/phpunit": "^11.0 || ^12.0",
         "spatie/ray": "^1.41.2"
     },
     "config": {
@@ -64,5 +64,7 @@
         "allow-plugins": {
             "pixelfear/composer-dist-plugin": true
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "moneyphp/money": "^4.5",
         "pixelfear/composer-dist-plugin": "^0.1.0",
         "statamic/cms": "^6.5",
-        "stillat/proteus": "^4.0",
+        "stillat/proteus": "^4.2.1",
         "stripe/stripe-php": "^16.4",
         "ext-zip": "*"
     },


### PR DESCRIPTION
This pull request adds Laravel 13 support to Cargo. Laravel 13 is due to be released [Early March](https://x.com/taylorotwell/status/2021555106269831216).

Depends on:
* [x] https://github.com/statamic/cms/pull/13870
* [x] https://github.com/Stillat/proteus/pull/37
