### PR TITLE
Add conditional capture for payment intent

### DIFF
--- a/src/Payments/Gateways/Stripe.php
+++ b/src/Payments/Gateways/Stripe.php
@@ -100,9 +100,11 @@ class Stripe extends PaymentGateway
     {
         $paymentIntent = PaymentIntent::retrieve($order->get('stripe_payment_intent'));
 
-        $paymentIntent = $paymentIntent->capture([
-            'amount_to_capture' => $order->grandTotal(),
-        ]);
+        if ($paymentIntent->status === PaymentIntent::STATUS_REQUIRES_CAPTURE) {
+            $paymentIntent = $paymentIntent->capture([
+                'amount_to_capture' => $order->grandTotal(),
+            ]);
+        }
 
         if ($paymentIntent->status === PaymentIntent::STATUS_SUCCEEDED) {
             $order->status(OrderStatus::PaymentReceived)->save();


### PR DESCRIPTION
Discovered this bug in our testing for a client, was captured by Sentry.

The `capture()` method in the Stripe gateway unconditionally calls `PaymentIntent::capture()` with no status guard. When the webhook job retries or fires after the intent is already `succeeded`, Stripe raises `InvalidRequestException: This PaymentIntent could not be captured because it has already been captured`.