### PR TITLE
Dump redundant sum method and require statamic/cms version 6.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "mollie/mollie-api-php": "^3.0",
         "moneyphp/money": "^4.5",
         "pixelfear/composer-dist-plugin": "^0.1.0",
-        "statamic/cms": "^6.0",
+        "statamic/cms": "^6.5",
         "stillat/proteus": "^4.0",
         "stripe/stripe-php": "^16.4",
         "ext-zip": "*"

--- a/src/Stache/Query/OrderQueryBuilder.php
+++ b/src/Stache/Query/OrderQueryBuilder.php
@@ -34,11 +34,6 @@ class OrderQueryBuilder extends Builder implements QueryBuilder
         return $this;
     }
 
-    public function sum(string $column)
-    {
-        return $this->pluck($column)->sum();
-    }
-
     protected function collect($items = [])
     {
         return DataCollection::make($items);

--- a/tests/Orders/OrderTest.php
+++ b/tests/Orders/OrderTest.php
@@ -56,9 +56,9 @@ class OrderTest extends TestCase
             'date from string, with time' => ['2025-04-05-1241', '2025-04-05 12:41:00', '2025-04-05-1241.1234'],
             'date from string, with seconds' => ['2025-04-05-124124', '2025-04-05 12:41:24', '2025-04-05-124124.1234'],
 
-            'date from carbon instance' => [Carbon::parse('2025-04-05'), '2025-04-05 00:00:00', '2025-04-05.1234'],
-            'date from carbon instance, with time' => [Carbon::parse('2025-04-05 12:41:00'), '2025-04-05 12:41:00', '2025-04-05-1241.1234'],
-            'date from carbon instance, with seconds' => [Carbon::parse('2025-04-05 12:41:24'), '2025-04-05 12:41:24', '2025-04-05-124124.1234'],
+            'date from carbon instance' => [Carbon::parse('2025-04-05', 'UTC'), '2025-04-05 00:00:00', '2025-04-05.1234'],
+            'date from carbon instance, with time' => [Carbon::parse('2025-04-05 12:41:00', 'UTC'), '2025-04-05 12:41:00', '2025-04-05-1241.1234'],
+            'date from carbon instance, with seconds' => [Carbon::parse('2025-04-05 12:41:24', 'UTC'), '2025-04-05 12:41:24', '2025-04-05-124124.1234'],
 
             'date from carbon instance in another timezone' => [Carbon::parse('2025-04-05 22:00', 'America/New_York'), '2025-04-06 02:00:00', '2025-04-06-0200.1234'],
         ];

--- a/tests/Tags/CartTagTest.php
+++ b/tests/Tags/CartTagTest.php
@@ -163,7 +163,7 @@ class CartTagTest extends TestCase
 
     private function tag($tag, $variables = [])
     {
-        return Parse::template($tag, $variables);
+        return (string) Parse::template($tag, $variables, [], true);
     }
 
     protected function makeCartWithLineItems($product = null)

--- a/tests/Tags/OrdersTagTest.php
+++ b/tests/Tags/OrdersTagTest.php
@@ -105,7 +105,7 @@ class OrdersTagTest extends TestCase
 
     private function tag($tag, $data = [])
     {
-        return (string) Parse::template($tag, $data);
+        return (string) Parse::template($tag, $data, [], true);
     }
 }
 

--- a/tests/Tags/PaymentGatewayTagTest.php
+++ b/tests/Tags/PaymentGatewayTagTest.php
@@ -40,6 +40,6 @@ class PaymentGatewayTagTest extends TestCase
 
     private function tag($tag, $variables = [])
     {
-        return Parse::template($tag, $variables);
+        return (string) Parse::template($tag, $variables, [], true);
     }
 }

--- a/tests/Tags/ShippingOptionsTagTest.php
+++ b/tests/Tags/ShippingOptionsTagTest.php
@@ -50,6 +50,6 @@ class ShippingOptionsTagTest extends TestCase
 
     private function tag($tag, $variables = [])
     {
-        return Parse::template($tag, $variables);
+        return (string) Parse::template($tag, $variables, [], true);
     }
 }


### PR DESCRIPTION
Statamic v6.5.0 ships a `sum` method on the Stache Query Builder. This PR removes the redundant `sum` method on the `OrderQueryBuilder` and requires Statamic v6.5.0.

I had to fix the tests because of the Antlers hardening in recent Statamic v6 releases. Please check if you agree with my approach.

Fixes #145 