### PR TITLE
Harden cart redirects

### DIFF
--- a/src/Http/Controllers/CartController.php
+++ b/src/Http/Controllers/CartController.php
@@ -8,6 +8,7 @@ use DuncanMcClean\Cargo\Http\Resources\API\CartResource;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\URL;
 
 class CartController
 {
@@ -36,7 +37,9 @@ class CartController
             return new CartResource($cart->fresh());
         }
 
-        return $request->_redirect ? redirect($request->_redirect) : back();
+        return $request->_redirect && ! URL::isExternalToApplication($request->_redirect)
+            ? redirect($request->_redirect)
+            : back();
     }
 
     public function destroy(Request $request)
@@ -50,6 +53,8 @@ class CartController
             return [];
         }
 
-        return $request->_redirect ? redirect($request->_redirect) : back();
+        return $request->_redirect && ! URL::isExternalToApplication($request->_redirect)
+            ? redirect($request->_redirect)
+            : back();
     }
 }

--- a/src/Http/Controllers/CartLineItemsController.php
+++ b/src/Http/Controllers/CartLineItemsController.php
@@ -11,6 +11,7 @@ use DuncanMcClean\Cargo\Http\Resources\API\CartResource;
 use DuncanMcClean\Cargo\Products\Actions\ValidateStock;
 use Illuminate\Http\Request;
 use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\URL;
 
 class CartLineItemsController
 {
@@ -42,7 +43,9 @@ class CartLineItemsController
             return new CartResource($cart->fresh());
         }
 
-        return $request->_redirect ? redirect($request->_redirect) : back();
+        return $request->_redirect && ! URL::isExternalToApplication($request->_redirect)
+            ? redirect($request->_redirect)
+            : back();
     }
 
     public function update(UpdateLineItemRequest $request, string $lineItem)
@@ -82,7 +85,9 @@ class CartLineItemsController
             return new CartResource($cart->fresh());
         }
 
-        return $request->_redirect ? redirect($request->_redirect) : back();
+        return $request->_redirect && ! URL::isExternalToApplication($request->_redirect)
+            ? redirect($request->_redirect)
+            : back();
     }
 
     public function destroy(Request $request, string $lineItem)
@@ -101,6 +106,8 @@ class CartLineItemsController
             return new CartResource($cart->fresh());
         }
 
-        return $request->_redirect ? redirect($request->_redirect) : back();
+        return $request->_redirect && ! URL::isExternalToApplication($request->_redirect)
+            ? redirect($request->_redirect)
+            : back();
     }
 }

--- a/src/Http/Requests/Cart/UpdateCartRequest.php
+++ b/src/Http/Requests/Cart/UpdateCartRequest.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\ValidationException;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 
 class UpdateCartRequest extends FormRequest
 {
@@ -38,7 +39,9 @@ class UpdateCartRequest extends FormRequest
         $url = $this->redirector->getUrlGenerator();
 
         if ($redirect = $this->input('_error_redirect')) {
-            return $url->to($redirect);
+            return URL::isExternalToApplication($redirect)
+                ? $url->previous()
+                : $url->to($redirect);
         }
 
         return $url->previous();

--- a/tests/Cart/CartControllerTest.php
+++ b/tests/Cart/CartControllerTest.php
@@ -113,6 +113,28 @@ class CartControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_redirects_when_updating_the_cart()
+    {
+        $this->makeCart();
+
+        $this
+            ->from('/cart')
+            ->patch('/!/cargo/cart', ['_redirect' => '/thank-you'])
+            ->assertRedirect('/thank-you');
+    }
+
+    #[Test]
+    public function it_doesnt_redirect_to_external_urls_when_updating_the_cart()
+    {
+        $this->makeCart();
+
+        $this
+            ->from('/cart')
+            ->patch('/!/cargo/cart', ['_redirect' => 'https://evil.com/path'])
+            ->assertRedirect('/cart');
+    }
+
+    #[Test]
     public function it_updates_the_cart_and_expects_a_json_response()
     {
         $cart = $this->makeCart();
@@ -187,6 +209,28 @@ class CartControllerTest extends TestCase
             ->assertRedirect('/cart');
 
         $this->assertNull(Cart::find($cart->id()));
+    }
+
+    #[Test]
+    public function it_redirects_when_deleting_the_cart()
+    {
+        $this->makeCart();
+
+        $this
+            ->from('/cart')
+            ->delete('/!/cargo/cart', ['_redirect' => '/'])
+            ->assertRedirect('/');
+    }
+
+    #[Test]
+    public function it_doesnt_redirect_to_external_urls_when_deleting_the_cart()
+    {
+        $this->makeCart();
+
+        $this
+            ->from('/cart')
+            ->delete('/!/cargo/cart', ['_redirect' => 'https://evil.com/path'])
+            ->assertRedirect('/cart');
     }
 
     #[Test]

--- a/tests/Cart/CartLineItemsControllerTest.php
+++ b/tests/Cart/CartLineItemsControllerTest.php
@@ -45,6 +45,38 @@ class CartLineItemsControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_redirects_when_adding_a_line_item()
+    {
+        $this->makeCart();
+        $product = $this->makeProduct();
+
+        $this
+            ->from('/products')
+            ->post('/!/cargo/cart/line-items', [
+                'product' => $product->id(),
+                'quantity' => 1,
+                '_redirect' => '/cart',
+            ])
+            ->assertRedirect('/cart');
+    }
+
+    #[Test]
+    public function it_doesnt_redirect_to_external_urls_when_adding_a_line_item()
+    {
+        $this->makeCart();
+        $product = $this->makeProduct();
+
+        $this
+            ->from('/products')
+            ->post('/!/cargo/cart/line-items', [
+                'product' => $product->id(),
+                'quantity' => 1,
+                '_redirect' => 'https://evil.com/path',
+            ])
+            ->assertRedirect('/products');
+    }
+
+    #[Test]
     public function it_adds_a_product_to_the_cart_and_expects_json_response()
     {
         $cart = $this->makeCart();
@@ -540,6 +572,34 @@ class CartLineItemsControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_redirects_when_updating_a_line_item()
+    {
+        $this->makeCartWithLineItems();
+
+        $this
+            ->from('/cart')
+            ->patch('/!/cargo/cart/line-items/line-item-1', [
+                'quantity' => 2,
+                '_redirect' => '/checkout',
+            ])
+            ->assertRedirect('/checkout');
+    }
+
+    #[Test]
+    public function it_doesnt_redirect_to_external_urls_when_updating_a_line_item()
+    {
+        $this->makeCartWithLineItems();
+
+        $this
+            ->from('/cart')
+            ->patch('/!/cargo/cart/line-items/line-item-1', [
+                'quantity' => 2,
+                '_redirect' => 'https://evil.com/path',
+            ])
+            ->assertRedirect('/cart');
+    }
+
+    #[Test]
     public function it_updates_a_line_item_with_a_different_variant()
     {
         $cart = $this->makeCart();
@@ -629,6 +689,28 @@ class CartLineItemsControllerTest extends TestCase
             ->assertJsonPath('data.id', $cart->id());
 
         $this->assertCount(0, $cart->fresh()->lineItems());
+    }
+
+    #[Test]
+    public function it_redirects_when_removing_a_line_item()
+    {
+        $this->makeCartWithLineItems();
+
+        $this
+            ->from('/cart')
+            ->delete('/!/cargo/cart/line-items/line-item-1', ['_redirect' => '/products'])
+            ->assertRedirect('/products');
+    }
+
+    #[Test]
+    public function it_doesnt_redirect_to_external_urls_when_removing_a_line_item()
+    {
+        $this->makeCartWithLineItems();
+
+        $this
+            ->from('/cart')
+            ->delete('/!/cargo/cart/line-items/line-item-1', ['_redirect' => 'https://evil.com/path'])
+            ->assertRedirect('/cart');
     }
 
     protected function makeCart()


### PR DESCRIPTION
This pull request implements redirect hardening on cart form tags, ensuring they can't redirect to external URLs for security purposes.