### PR TITLE
Use select mode for tax class field

### DIFF
--- a/src/Listeners/EnsureProductFields.php
+++ b/src/Listeners/EnsureProductFields.php
@@ -36,6 +36,8 @@ class EnsureProductFields
                 'max_items' => 1,
                 'create' => true,
                 'validate' => 'required',
+                'default' => 'general',
+                'mode' => 'select',
             ], 'sidebar');
         }
 


### PR DESCRIPTION
This pull request updates the configuration for the "Tax Class" field added to new product blueprints. It specifies the relationship fieldtype's `select` mode and adds a default value.