### PR TITLE
Fix error from states field when editing tax class

### DIFF
--- a/resources/js/components/fieldtypes/StatesFieldtype.vue
+++ b/resources/js/components/fieldtypes/StatesFieldtype.vue
@@ -162,6 +162,10 @@ export default {
                 this.update(null);
             }
 
+			if (Array.isArray(country)) {
+				country = country[0];
+			}
+
             this.request({ country }).then((response) => (this.loading = false));
         },
     },


### PR DESCRIPTION
This pull request fixes a 500 error from the states field when editing tax classes, due to the `country` field being an array instead of a string.

Fixes #152
