### PR TITLE
Harden OrderBys

### DIFF
--- a/src/Http/Controllers/CP/Discounts/DiscountController.php
+++ b/src/Http/Controllers/CP/Discounts/DiscountController.php
@@ -12,6 +12,7 @@ use Statamic\CP\PublishForm;
 use Statamic\Facades\Scope;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
+use Statamic\Query\OrderBy;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 use Statamic\Support\Arr;
 
@@ -28,7 +29,7 @@ class DiscountController extends CpController
 
             $activeFilterBadges = $this->queryFilters($query, $request->filters);
 
-            $sortField = request('sort');
+            $sortField = OrderBy::column(request('sort'));
             $sortDirection = request('order', 'asc');
 
             if (! $sortField && ! request('search')) {

--- a/src/Http/Controllers/CP/Orders/OrderController.php
+++ b/src/Http/Controllers/CP/Orders/OrderController.php
@@ -14,6 +14,7 @@ use Statamic\Facades\Scope;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
+use Statamic\Query\OrderBy;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 
 class OrderController extends CpController
@@ -29,7 +30,7 @@ class OrderController extends CpController
 
             $activeFilterBadges = $this->queryFilters($query, $request->filters);
 
-            $sortField = request('sort');
+            $sortField = OrderBy::column(request('sort'));
             $sortDirection = request('order', 'asc');
 
             if (! $sortField && ! request('search')) {


### PR DESCRIPTION
This PR prevents invalid column names being used in orderbys/sorts.

Requires https://github.com/statamic/cms/pull/14421