### PR TITLE
Add `LineItem` to serializable classes allowlist

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -80,6 +80,7 @@ class ServiceProvider extends AddonServiceProvider
             \DuncanMcClean\Cargo\Cart\Cart::class,
             \DuncanMcClean\Cargo\Discounts\Discount::class,
             \DuncanMcClean\Cargo\Orders\Order::class,
+            \DuncanMcClean\Cargo\Orders\LineItem::class,
             \DuncanMcClean\Cargo\Products\Product::class,
         ]);
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -81,6 +81,7 @@ class ServiceProvider extends AddonServiceProvider
             \DuncanMcClean\Cargo\Discounts\Discount::class,
             \DuncanMcClean\Cargo\Orders\Order::class,
             \DuncanMcClean\Cargo\Orders\LineItem::class,
+            \DuncanMcClean\Cargo\Orders\LineItems::class,
             \DuncanMcClean\Cargo\Products\Product::class,
         ]);
     }


### PR DESCRIPTION
This pull request adds the `LineItem` class to the serializable class allowlist added in https://github.com/duncanmcclean/cargo/pull/159.

Fixes #161

