### PR TITLE
Fix amount off discount calculation when not perfectly divisible

### DIFF
--- a/src/Discounts/Types/AmountOff.php
+++ b/src/Discounts/Types/AmountOff.php
@@ -13,9 +13,8 @@ class AmountOff extends DiscountType
     {
         $discountValue = (int) $this->discount->get('amount_off');
 
-        $eligibleSubtotal = $cart->lineItems()
-            ->filter(fn (LineItem $line) => $this->isValidForLineItem($cart, $line))
-            ->sum(fn (LineItem $line) => $line->total());
+        $eligibleLineItems = $cart->lineItems()->filter(fn (LineItem $line) => $this->isValidForLineItem($cart, $line));
+        $eligibleSubtotal = $eligibleLineItems->sum(fn (LineItem $line) => $line->total());
 
         if ($eligibleSubtotal <= 0) {
             return 0;
@@ -29,6 +28,18 @@ class AmountOff extends DiscountType
         // Calculate this line item's proportional share of the discount.
         $lineTotal = $lineItem->total();
         $proportion = $lineTotal / $eligibleSubtotal;
+
+        // If this is the last eligible line item, give it the remainder to avoid
+        // losing cents due to rounding errors when the discount isn't perfectly divisible.
+        $lastEligibleLineItem = $eligibleLineItems->last();
+
+        if ($lastEligibleLineItem && $lastEligibleLineItem->id() === $lineItem->id()) {
+            $allocatedToOthers = $eligibleLineItems
+                ->filter(fn (LineItem $line) => $line->id() !== $lineItem->id())
+                ->sum(fn (LineItem $line) => (int) floor($discountValue * ($line->total() / $eligibleSubtotal)));
+
+            return $discountValue - $allocatedToOthers;
+        }
 
         return (int) floor($discountValue * $proportion);
     }

--- a/tests/Discounts/Types/AmountOffTest.php
+++ b/tests/Discounts/Types/AmountOffTest.php
@@ -64,4 +64,30 @@ class AmountOffTest extends TestCase
         $this->assertEquals(75, $amountLine2);
         $this->assertEquals(100, $amountLine1 + $amountLine2);
     }
+
+    /**
+     * @see https://github.com/duncanmcclean/statamic-cargo/issues/164
+     */
+    #[Test]
+    public function it_distributes_fixed_amount_without_rounding_errors_when_not_perfectly_divisible()
+    {
+        // When 1000 (CHF 10) is divided by 3 equal line items, each gets 333.33...
+        // Using floor() would give 333 + 333 + 333 = 999, losing 1 cent
+        $discount = Discount::make()->type('amount_off')->set('amount_off', 1000);
+
+        $cart = Cart::make();
+        $cart->lineItems()->create(['id' => 'line1', 'total' => 3333]);
+        $cart->lineItems()->create(['id' => 'line2', 'total' => 3333]);
+        $cart->lineItems()->create(['id' => 'line3', 'total' => 3334]);
+
+        $discountType = (new AmountOff)->setDiscount($discount);
+
+        $amountLine1 = $discountType->calculate($cart, $cart->lineItems()->find('line1'));
+        $amountLine2 = $discountType->calculate($cart, $cart->lineItems()->find('line2'));
+        $amountLine3 = $discountType->calculate($cart, $cart->lineItems()->find('line3'));
+
+        // The total discount applied should equal the full discount amount (1000)
+        // not 999 due to rounding errors
+        $this->assertEquals(1000, $amountLine1 + $amountLine2 + $amountLine3);
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue where fixed amount discounts (e.g., CHF 10) would lose cents when distributed across line items that don't divide evenly.

This was happening because the proportional share for each line item was calculated using `floor()`, which truncates downward. When distributing 1000 cents across 3 equal line items, each would receive `floor(333.33) = 333`, totaling only 999 cents instead of 1000.

This PR fixes it by detecting the last eligible line item and giving it the remainder (`discount - sum_of_other_allocations`) instead of its own floored proportional share. This ensures the full discount amount is always applied.

Fixes #164