### PR TITLE
Add `always_checkout_as_guest` config option

### DIFF
--- a/config/cargo.php
+++ b/config/cargo.php
@@ -108,6 +108,19 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | Always checkout as guest
+        |--------------------------------------------------------------------------
+        |
+        | By default, when a logged-in user checks out, Cargo will associate the order
+        | with their user account. Enable this option to always create guest customers
+        | instead, even when users are logged in.
+        |
+        */
+
+        'always_checkout_as_guest' => false,
+
+        /*
+        |--------------------------------------------------------------------------
         | Cookie Name
         |--------------------------------------------------------------------------
         |

--- a/docs/docs/customers.md
+++ b/docs/docs/customers.md
@@ -33,3 +33,18 @@ You can disable this behaviour in the `cargo.php` config file:
 	'merge_on_login' => true,
 ],
 ```
+
+## Always checkout as guest
+By default, when a logged-in user checks out, Cargo will associate the order with their user account.
+
+If you'd prefer to always create guest customers instead (even when users are logged in), you may enable the `always_checkout_as_guest` option:
+
+```php
+// config/statamic/cargo.php
+
+'carts' => [
+	'always_checkout_as_guest' => true,
+],
+```
+
+When enabled, customer details will be saved on the order, rather than being linked to a user account.

--- a/src/Http/Controllers/Concerns/HandlesCustomerInformation.php
+++ b/src/Http/Controllers/Concerns/HandlesCustomerInformation.php
@@ -18,7 +18,7 @@ trait HandlesCustomerInformation
             'email' => $request->email,
         ])->filter()->all());
 
-        if ($user = User::current()) {
+        if (! config('statamic.cargo.carts.always_checkout_as_guest') && $user = User::current()) {
             // When a customer is missing from the order, we'll set it to the logged-in user.
             if (! $cart->customer()) {
                 $cart->customer($user);

--- a/tests/Cart/CartControllerTest.php
+++ b/tests/Cart/CartControllerTest.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
+use Statamic\Facades\User;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -196,6 +197,88 @@ class CartControllerTest extends TestCase
             ->assertSessionHasErrors('customer.email');
 
         $this->assertNull($cart->fresh()->customer());
+    }
+
+    #[Test]
+    public function it_assigns_logged_in_user_to_cart_by_default()
+    {
+        config()->set('statamic.cargo.carts.always_checkout_as_guest', false);
+
+        $cart = $this->makeCart();
+        $cart->customer(null)->save();
+
+        $user = User::make()->email('user@example.com')->save();
+
+        $this->actingAs($user)
+            ->from('/cart')
+            ->patch('/!/cargo/cart', [
+                'customer' => [
+                    'name' => 'John Doe',
+                    'email' => 'john@example.com',
+                ],
+            ])
+            ->assertRedirect('/cart');
+
+        $cart = $cart->fresh();
+
+        $this->assertNotInstanceOf(GuestCustomer::class, $cart->customer());
+        $this->assertEquals($user->id(), $cart->customer()->id());
+    }
+
+    #[Test]
+    public function it_creates_guest_customer_when_always_checkout_as_guest_is_enabled()
+    {
+        config()->set('statamic.cargo.carts.always_checkout_as_guest', true);
+
+        $cart = $this->makeCart();
+        $cart->customer(null)->save();
+
+        $user = User::make()->email('user@example.com')->save();
+
+        $this->actingAs($user)
+            ->from('/cart')
+            ->patch('/!/cargo/cart', [
+                'customer' => [
+                    'name' => 'John Doe',
+                    'email' => 'john@example.com',
+                ],
+            ])
+            ->assertRedirect('/cart');
+
+        $cart = $cart->fresh();
+
+        $this->assertInstanceOf(GuestCustomer::class, $cart->customer());
+        $this->assertEquals('John Doe', $cart->customer()->name());
+        $this->assertEquals('john@example.com', $cart->customer()->email());
+    }
+
+    #[Test]
+    public function it_does_not_update_user_data_when_always_checkout_as_guest_is_enabled()
+    {
+        config()->set('statamic.cargo.carts.always_checkout_as_guest', true);
+
+        $cart = $this->makeCart();
+        $cart->customer(null)->save();
+
+        $user = User::make()
+            ->email('original@example.com')
+            ->set('name', 'Original Name')
+            ->save();
+
+        $this->actingAs($user)
+            ->from('/cart')
+            ->patch('/!/cargo/cart', [
+                'customer' => [
+                    'name' => 'New Name',
+                    'email' => 'new@example.com',
+                ],
+            ])
+            ->assertRedirect('/cart');
+
+        $user = User::find($user->id());
+
+        $this->assertEquals('original@example.com', $user->email());
+        $this->assertEquals('Original Name', $user->get('name'));
     }
 
     #[Test]


### PR DESCRIPTION
This pull request adds an `always_checkout_as_guest` config option, forcing customer details to be saved on the order, rather than it being associated with the user's account.

```php
// config/statamic/cargo.php

'carts' => [
    'always_checkout_as_guest' => true,
],
```

Related: #165