### PR TITLE
Harden query value resolution

### DIFF
--- a/src/Cart/Cart.php
+++ b/src/Cart/Cart.php
@@ -388,7 +388,7 @@ class Cart implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableValu
             return $this->customer;
         }
 
-        if (method_exists($this, $method = Str::camel($field))) {
+        if (in_array($method = Str::camel($field), $this->queryableMethods())) {
             return $this->{$method}();
         }
 
@@ -399,5 +399,14 @@ class Cart implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableValu
         }
 
         return $field->fieldtype()->toQueryableValue($value);
+    }
+
+    private function queryableMethods(): array
+    {
+        return [
+            'billingAddress', 'blueprint', 'customer', 'discountTotal', 'grandTotal', 'hasBillingAddress', 'hasShippingAddress',
+            'id', 'isFree', 'isPaid', 'lineItems', 'path', 'paymentGateway', 'reference', 'shippingAddress', 'shippingMethod',
+            'shippingOption', 'shippingTotal', 'site', 'subTotal', 'taxableAddress', 'taxBreakdown', 'taxTotal',
+        ];
     }
 }

--- a/src/Discounts/Discount.php
+++ b/src/Discounts/Discount.php
@@ -205,7 +205,7 @@ class Discount implements Arrayable, ArrayAccess, Augmentable, ContainsQueryable
 
     public function getQueryableValue(string $field)
     {
-        if (method_exists($this, $method = Str::camel($field))) {
+        if (in_array($method = Str::camel($field), $this->queryableMethods())) {
             return $this->{$method}();
         }
 
@@ -216,5 +216,12 @@ class Discount implements Arrayable, ArrayAccess, Augmentable, ContainsQueryable
         }
 
         return $field->fieldtype()->toQueryableValue($value);
+    }
+
+    private function queryableMethods(): array
+    {
+        return [
+            'discountType', 'editUrl', 'handle', 'id', 'reference', 'title', 'type', 'updateUrl',
+        ];
     }
 }

--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -475,7 +475,7 @@ class Order implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
             return $this->customer;
         }
 
-        if (method_exists($this, $method = Str::camel($field))) {
+        if (in_array($method = Str::camel($field), $this->queryableMethods())) {
             return $this->{$method}();
         }
 
@@ -486,5 +486,15 @@ class Order implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
         }
 
         return $field->fieldtype()->toQueryableValue($value);
+    }
+
+    private function queryableMethods(): array
+    {
+        return [
+            'billingAddress', 'blueprint', 'cart', 'customer', 'date', 'discountTotal', 'editUrl', 'grandTotal', 'hasBillingAddress',
+            'hasSeconds', 'hasShippingAddress', 'hasTime', 'id', 'isFree', 'isPaid', 'lineItems', 'orderNumber', 'path',
+            'paymentGateway', 'reference', 'shippingAddress', 'shippingMethod', 'shippingOption', 'shippingTotal', 'site', 'status',
+            'subTotal', 'taxableAddress', 'taxBreakdown', 'taxTotal', 'timelineEvents', 'updateUrl',
+        ];
     }
 }

--- a/src/Products/Productable.php
+++ b/src/Products/Productable.php
@@ -6,6 +6,7 @@ use DuncanMcClean\Cargo\Contracts\Taxes\TaxClass as TaxClassContract;
 use DuncanMcClean\Cargo\Facades\TaxClass;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Statamic\Support\Str;
 
 trait Productable
 {
@@ -97,5 +98,21 @@ trait Productable
         }
 
         return TaxClass::find($taxClass);
+    }
+
+    public function getQueryableValue(string $field)
+    {
+        if (in_array($method = Str::camel($field), $this->productQueryableMethods())) {
+            return $this->{$method}();
+        }
+
+        return parent::getQueryableValue($field);
+    }
+
+    private function productQueryableMethods(): array
+    {
+        return [
+            'isStandardProduct', 'isStockEnabled', 'isVariantProduct', 'price', 'productVariants', 'stock',
+        ];
     }
 }

--- a/tests/Stache/Query/CartQueryBuilderTest.php
+++ b/tests/Stache/Query/CartQueryBuilderTest.php
@@ -83,4 +83,19 @@ class CartQueryBuilderTest extends TestCase
         $this->assertCount(2, $query);
         $this->assertEquals([123, 789], $query->map->id()->all());
     }
+
+    #[Test]
+    public function sorting_by_unsafe_method_does_not_invoke_it()
+    {
+        Cart::make()->id('abc')->save();
+        Cart::make()->id('def')->save();
+        Cart::make()->id('ghi')->save();
+
+        $count = Cart::all()->count();
+        $this->assertGreaterThan(0, $count);
+
+        Cart::query()->orderBy('delete', 'asc')->get();
+
+        $this->assertCount($count, Cart::all());
+    }
 }

--- a/tests/Stache/Query/DiscountQueryBuilderTest.php
+++ b/tests/Stache/Query/DiscountQueryBuilderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Stache\Query;
+
+use DuncanMcClean\Cargo\Facades\Discount;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class DiscountQueryBuilderTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    #[Test]
+    public function sorting_by_unsafe_method_does_not_invoke_it()
+    {
+        Discount::make()->handle('abc')->save();
+        Discount::make()->handle('def')->save();
+        Discount::make()->handle('ghi')->save();
+
+        $count = Discount::all()->count();
+        $this->assertGreaterThan(0, $count);
+
+        Discount::query()->orderBy('delete', 'asc')->get();
+
+        $this->assertCount($count, Discount::all());
+    }
+}

--- a/tests/Stache/Query/DiscountQueryBuilderTest.php
+++ b/tests/Stache/Query/DiscountQueryBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Stache\Query;
+namespace Tests\Stache\Query;
 
 use DuncanMcClean\Cargo\Facades\Discount;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Stache/Query/DiscountQueryBuilderTest.php
+++ b/tests/Stache/Query/DiscountQueryBuilderTest.php
@@ -12,6 +12,19 @@ class DiscountQueryBuilderTest extends TestCase
     use PreventsSavingStacheItemsToDisk;
 
     #[Test]
+    public function can_query_columns()
+    {
+        Discount::make()->handle('a')->type('percentage_off')->set('percentage_off', 10)->save();
+        Discount::make()->handle('b')->type('amount_off')->set('percentage_off', 1500)->save();
+        Discount::make()->handle('c')->type('percentage_off')->set('percentage_off', 15)->save();
+
+        $query = Discount::query()->where('type', 'percentage_off')->get();
+
+        $this->assertCount(2, $query);
+        $this->assertEquals(['a', 'c'], $query->map->id()->all());
+    }
+
+    #[Test]
     public function sorting_by_unsafe_method_does_not_invoke_it()
     {
         Discount::make()->handle('abc')->save();

--- a/tests/Stache/Query/OrderQueryBuilderTest.php
+++ b/tests/Stache/Query/OrderQueryBuilderTest.php
@@ -118,4 +118,19 @@ class OrderQueryBuilderTest extends TestCase
         $this->assertCount(2, $query);
         $this->assertEquals([123, 789], $query->map->id()->all());
     }
+
+    #[Test]
+    public function sorting_by_unsafe_method_does_not_invoke_it()
+    {
+        Order::make()->id('abc')->save();
+        Order::make()->id('def')->save();
+        Order::make()->id('ghi')->save();
+
+        $count = Order::all()->count();
+        $this->assertGreaterThan(0, $count);
+
+        Order::query()->orderBy('delete', 'asc')->get();
+
+        $this->assertCount($count, Order::all());
+    }
 }

--- a/tests/Stache/Query/OrderQueryBuilderTest.php
+++ b/tests/Stache/Query/OrderQueryBuilderTest.php
@@ -122,9 +122,9 @@ class OrderQueryBuilderTest extends TestCase
     #[Test]
     public function sorting_by_unsafe_method_does_not_invoke_it()
     {
-        Order::make()->id('abc')->save();
-        Order::make()->id('def')->save();
-        Order::make()->id('ghi')->save();
+        Order::make()->id('abc')->customer(['name' => 'Foo', 'email' => 'foo@example.com'])->save();
+        Order::make()->id('def')->customer(['name' => 'Bar', 'email' => 'bar@example.com'])->save();
+        Order::make()->id('ghi')->customer(['name' => 'Baz', 'email' => 'baz@example.com'])->save();
 
         $count = Order::all()->count();
         $this->assertGreaterThan(0, $count);


### PR DESCRIPTION
This PR adds explicit method allowlists to `getQueryableValue()` across various classes, replacing the previous open-ended `method_exists()` check.