### PR TITLE
Add missing 'path' to Discount queryableMethods

### DIFF
--- a/src/Discounts/Discount.php
+++ b/src/Discounts/Discount.php
@@ -221,7 +221,7 @@ class Discount implements Arrayable, ArrayAccess, Augmentable, ContainsQueryable
     private function queryableMethods(): array
     {
         return [
-            'discountType', 'editUrl', 'handle', 'id', 'reference', 'title', 'type', 'updateUrl',
+            'discountType', 'editUrl', 'handle', 'id', 'path', 'reference', 'title', 'type', 'updateUrl',
         ];
     }
 }


### PR DESCRIPTION
## Summary

- Adds `'path'` to the `queryableMethods()` array in `Discount`, matching `Cart` and `Order`

Fixes #174

## Problem

The `Discount` class is missing `'path'` in its `queryableMethods()` array. This causes the stache path index to overwrite the path cache with null values during `stache:warm`, because `getQueryableValue('path')` falls through to a data lookup instead of calling `$this->path()`.

After any deployment that clears and warms the stache, all discount paths become null, resulting in errors when listing discounts in the CP or applying discounts to carts.