### PR TITLE
Remove return type from query builder `column()`

### DIFF
--- a/src/Cart/Eloquent/CartQueryBuilder.php
+++ b/src/Cart/Eloquent/CartQueryBuilder.php
@@ -57,7 +57,7 @@ class CartQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         });
     }
 
-    protected function column($column): string
+    protected function column($column)
     {
         if (! is_string($column)) {
             return $column;

--- a/src/Orders/Eloquent/OrderQueryBuilder.php
+++ b/src/Orders/Eloquent/OrderQueryBuilder.php
@@ -57,7 +57,7 @@ class OrderQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         });
     }
 
-    protected function column($column): string
+    protected function column($column): string|Closure
     {
         if (! is_string($column)) {
             return $column;

--- a/src/Orders/Eloquent/OrderQueryBuilder.php
+++ b/src/Orders/Eloquent/OrderQueryBuilder.php
@@ -57,7 +57,7 @@ class OrderQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
         });
     }
 
-    protected function column($column): string|Closure
+    protected function column($column)
     {
         if (! is_string($column)) {
             return $column;


### PR DESCRIPTION
## Bug

When searching orders in the CP, the `indexQuery()` method in `OrderController` passes a Closure to `orWhere()`:

```php
->orWhere(function ($query) use ($search) {
    // ...
})
```

This calls `OrderQueryBuilder::where()`, which calls `$this->column($column)`. The `column()` method has a return type of `string`, but when `$column` is a Closure, it returns the Closure (line 63), causing a `TypeError`:

```
OrderQueryBuilder::column(): Return value must be of type string, Closure returned
```

## Fix

The return type of `column()` should be `string|Closure`:

```php
protected function column($column): string|Closure
```

## Steps to Reproduce

1. Go to CP > Orders
2. Type a search query (e.g. an email address)
3. 500 error is thrown

## Environment

- Statamic 6
- PHP 8.5
