### PR TITLE
Add PreventRequestForgery to CSRF middleware exclusion for Laravel 13

### DIFF
--- a/routes/actions.php
+++ b/routes/actions.php
@@ -29,7 +29,7 @@ Route::name('cargo.')->group(function () {
 
     Route::name('payments.')
         ->prefix('payments')
-        ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken'])
+        ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\PreventRequestForgery'])
         ->group(function () {
             Route::post('{paymentGateway}/webhook', WebhookController::class)->name('webhook');
             Route::match(['get', 'post'], '{paymentGateway}/checkout', CheckoutController::class)->name('checkout');


### PR DESCRIPTION
## Summary

Adds `Illuminate\Foundation\Http\Middleware\PreventRequestForgery` to the `withoutMiddleware` exclusion list on payment routes.

In Laravel 13, the CSRF middleware was renamed from `VerifyCsrfToken` to `PreventRequestForgery`. The `web` middleware group now registers `PreventRequestForgery`, so the existing exclusions for `VerifyCsrfToken` no longer match. This causes webhook POST requests to return 419 CSRF errors, preventing payment capture for gateways using `capture_method: manual`.

Fixes #181
