### PR TITLE
Support storing discounts in the database

### DIFF
--- a/config/cargo.php
+++ b/config/cargo.php
@@ -49,12 +49,19 @@ return [
         | Storage
         |--------------------------------------------------------------------------
         |
-        | Discounts are stored in flat files. If you need to change the location of
-        | them, you can do that here.
+        | By default, discounts are stored in flat files. However, it's also possible
+        | to store them in a database by changing the "driver" to "eloquent".
+        |
+        | Learn more at https://builtwithcargo.dev/docs/discounts
         |
         */
 
+        'driver' => 'file',
+
         'directory' => base_path('content/cargo/discounts'),
+
+        // 'model' => \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountModel::class,
+        // 'table' => 'cargo_discounts',
 
     ],
 

--- a/docs/docs/discounts.md
+++ b/docs/docs/discounts.md
@@ -25,6 +25,36 @@ Discounts can be configured using various conditions and limitations. Most of th
 
 Cargo supports "Amount off" and "Percentage off" discount types out-of-the-box, with more on the way. If you need to, you can also [build your own discount type](#building-your-own-discount-type).
 
+## Storage
+Out of the box, discounts are stored as YAML files in the `content/cargo/discounts` directory. If you wish, you can change the directory in the `cargo.php` config file:
+
+```php
+// config/statamic/cargo.php
+
+'discounts' => [
+    'repository' => 'file',  
+  
+    'directory' => base_path('discounts'),
+],
+```
+
+### Database
+You can also opt to store discounts in a traditional database, which might be useful if you have a large number of discounts.
+
+To move discounts to the database, run this command:
+
+```
+php please cargo:database-discounts
+```
+
+It'll automatically publish database migrations, update your `cargo.php` config file and import existing discounts into the database.
+
+If needed, you can customise the eloquent model Cargo uses by updating the `model` key in the `cargo.php` config file. 
+
+:::tip warning
+Make sure you have a backup strategy in place before moving discounts to the database, in case the worst happens. Both [Laravel Forge](https://forge.laravel.com/docs/servers/backups) and [Ploi](https://ploi.io/features/database-backups) have built-in solutions for database backups.
+:::
+
 ## Redeem discount codes
 You can redeem discount codes using the `{{ cart:update }}` form. Simply provide a `discount_code` input so the customer can enter their discount code.
 

--- a/src/Commands/DatabaseDiscounts.php
+++ b/src/Commands/DatabaseDiscounts.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Commands;
+
+use DuncanMcClean\Cargo\Contracts\Discounts\Discount as DiscountContract;
+use DuncanMcClean\Cargo\Facades\Discount;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Artisan;
+use Statamic\Console\RunsInPlease;
+use Statamic\Statamic;
+use Stillat\Proteus\Support\Facades\ConfigWriter;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\progress;
+
+class DatabaseDiscounts extends Command
+{
+    use Concerns\PublishesMigrations, RunsInPlease;
+
+    protected $signature = 'statamic:cargo:database-discounts
+        { --import : Whether existing data should be imported }';
+
+    protected $description = 'Migrates discounts to the database.';
+
+    public function handle(): void
+    {
+        app()->bind('cargo.discounts.eloquent.model', function () {
+            return \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountModel::class;
+        });
+
+        Statamic::repository(
+            \DuncanMcClean\Cargo\Contracts\Discounts\DiscountRepository::class,
+            \DuncanMcClean\Cargo\Stache\Repositories\DiscountRepository::class
+        );
+
+        $this
+            ->publishMigrations()
+            ->runMigrations()
+            ->importDiscounts()
+            ->updateConfig();
+    }
+
+    private function publishMigrations(): self
+    {
+        $this->publishMigration(
+            stubPath: __DIR__.'/stubs/create_discounts_table.php.stub',
+            name: 'create_cargo_discounts_table.php',
+            replacements: [
+                'DISCOUNTS_TABLE' => config('statamic.cargo.discounts.table', 'cargo_discounts'),
+            ]
+        );
+
+        return $this;
+    }
+
+    private function runMigrations(): self
+    {
+        Artisan::call('migrate', ['--force' => true], $this->output);
+
+        $this->newLine();
+
+        return $this;
+    }
+
+    private function importDiscounts(): self
+    {
+        if (
+            ! $this->input->isInteractive()
+            || (! $this->option('import') && ! confirm('Would you like to import existing discounts?'))
+        ) {
+            return $this;
+        }
+
+        $query = Discount::query();
+
+        $progress = progress(label: 'Importing discounts', steps: $query->count());
+
+        $progress->start();
+
+        $query->chunk(50, function (Collection $discounts) use ($progress) {
+            $discounts->each(function (DiscountContract $discount) use ($progress) {
+                app('cargo.discounts.eloquent.model')::updateOrCreate(
+                    ['handle' => $discount->handle()],
+                    [
+                        'title' => $discount->title(),
+                        'type' => $discount->type(),
+                        'data' => $discount->data()->except('id')->all(),
+                    ]
+                );
+
+                $progress->advance();
+            });
+        });
+
+        $progress->finish();
+
+        $this->components->info('Discounts imported successfully.');
+
+        return $this;
+    }
+
+    private function updateConfig(): self
+    {
+        if (config('statamic.cargo.discounts.driver') === 'eloquent') {
+            $this->components->info('Discounts repository is already set to `eloquent`.');
+
+            return $this;
+        }
+
+        ConfigWriter::write('statamic.cargo.discounts.driver', 'eloquent');
+
+        $this->components->info('Cargo discounts driver set to `eloquent`.');
+
+        return $this;
+    }
+}

--- a/src/Commands/stubs/create_discounts_table.php.stub
+++ b/src/Commands/stubs/create_discounts_table.php.stub
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('DISCOUNTS_TABLE', function (Blueprint $table) {
+            $table->id();
+            $table->string('handle')->unique();
+            $table->string('title')->nullable();
+            $table->string('type')->nullable();
+            $table->json('data')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('DISCOUNTS_TABLE');
+    }
+};

--- a/src/Discounts/Eloquent/Discount.php
+++ b/src/Discounts/Eloquent/Discount.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Discounts\Eloquent;
+
+use DuncanMcClean\Cargo\Contracts\Discounts\Discount as DiscountContract;
+use DuncanMcClean\Cargo\Discounts\Discount as StacheDiscount;
+
+class Discount extends StacheDiscount
+{
+    protected $model;
+
+    public static function fromModel(DiscountModel $model): self
+    {
+        return (new static)
+            ->model($model)
+            ->handle($model->handle)
+            ->title($model->title)
+            ->type($model->type)
+            ->data([
+                ...$model->data ?? [],
+                'updated_at' => $model->updated_at,
+            ]);
+    }
+
+    public static function makeModelFromContract(DiscountContract $source): DiscountModel
+    {
+        $class = app('cargo.discounts.eloquent.model');
+
+        $attributes = [
+            'handle' => $source->handle(),
+            'title' => $source->title(),
+            'type' => $source->type(),
+            'data' => $source->data()->except('updated_at')->all(),
+        ];
+
+        return $class::firstOrNew(['handle' => $source->handle()])->fill($attributes);
+    }
+
+    public function toModel()
+    {
+        return self::makeModelFromContract($this);
+    }
+
+    public function model($model = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->model;
+        }
+
+        $this->model = $model;
+
+        return $this;
+    }
+
+    public function defaultAugmentedArrayKeys()
+    {
+        return [];
+    }
+}

--- a/src/Discounts/Eloquent/DiscountModel.php
+++ b/src/Discounts/Eloquent/DiscountModel.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Discounts\Eloquent;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DiscountModel extends Model
+{
+    protected $guarded = [];
+
+    public function casts(): array
+    {
+        return [
+            'data' => 'json',
+        ];
+    }
+
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->setTable(config('statamic.cargo.discounts.table', 'cargo_discounts'));
+    }
+}

--- a/src/Discounts/Eloquent/DiscountQueryBuilder.php
+++ b/src/Discounts/Eloquent/DiscountQueryBuilder.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Discounts\Eloquent;
+
+use DuncanMcClean\Cargo\Contracts\Discounts\QueryBuilder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Statamic\Query\EloquentQueryBuilder;
+
+class DiscountQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
+{
+    protected $columns = [
+        'id', 'handle', 'title', 'type', 'data',
+    ];
+
+    public function orderBy($column, $direction = 'asc')
+    {
+        $column = $this->column($column);
+
+        return parent::orderBy($column, $direction);
+    }
+
+    public function where($column, $operator = null, $value = null, $boolean = 'and')
+    {
+        $column = $this->column($column);
+
+        return parent::where($column, $operator, $value, $boolean);
+    }
+
+    public function pluck($column, $key = null)
+    {
+        $column = $this->column($column);
+
+        return $this->builder->pluck($column, $key);
+    }
+
+    protected function transform($items, $columns = ['*'])
+    {
+        return Collection::make($items)->map(function ($model) {
+            return Discount::fromModel($model);
+        });
+    }
+
+    protected function column($column)
+    {
+        if (! is_string($column)) {
+            return $column;
+        }
+
+        if (! in_array($column, $this->columns)) {
+            if (! Str::startsWith($column, 'data->')) {
+                $column = 'data->'.$column;
+            }
+        }
+
+        return $column;
+    }
+}

--- a/src/Discounts/Eloquent/DiscountRepository.php
+++ b/src/Discounts/Eloquent/DiscountRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Discounts\Eloquent;
+
+use DuncanMcClean\Cargo\Contracts\Discounts\Discount;
+use DuncanMcClean\Cargo\Contracts\Discounts\DiscountRepository as RepositoryContract;
+use DuncanMcClean\Cargo\Contracts\Discounts\QueryBuilder;
+use DuncanMcClean\Cargo\Stache;
+use Illuminate\Support\Str;
+
+class DiscountRepository extends Stache\Repositories\DiscountRepository implements RepositoryContract
+{
+    public function query(): QueryBuilder
+    {
+        return app(QueryBuilder::class, ['builder' => app('cargo.discounts.eloquent.model')::query()]);
+    }
+
+    public function save(Discount $discount): void
+    {
+        if (! $discount->handle()) {
+            $discount->handle(Str::slug($discount->title()));
+        }
+
+        $model = $discount->toModel();
+
+        $model->save();
+
+        $model = $model->fresh();
+
+        $discount->model($model);
+    }
+
+    public function delete(Discount $discount): void
+    {
+        $discount->model()->delete();
+    }
+
+    public static function bindings(): array
+    {
+        return [
+            Discount::class => \DuncanMcClean\Cargo\Discounts\Eloquent\Discount::class,
+            QueryBuilder::class => DiscountQueryBuilder::class,
+        ];
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -196,6 +196,17 @@ class ServiceProvider extends AddonServiceProvider
             );
         }
 
+        if (config('statamic.cargo.discounts.driver') === 'eloquent') {
+            $this->app->bind('cargo.discounts.eloquent.model', function () {
+                return config('statamic.cargo.discounts.model', \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountModel::class);
+            });
+
+            Statamic::repository(
+                \DuncanMcClean\Cargo\Contracts\Discounts\DiscountRepository::class,
+                \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountRepository::class
+            );
+        }
+
         return $this;
     }
 

--- a/tests/Discounts/Eloquent/DiscountQueryBuilderTest.php
+++ b/tests/Discounts/Eloquent/DiscountQueryBuilderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Discounts\Eloquent;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Statamic\Statamic;
+use Tests\Stache\Query\DiscountQueryBuilderTest as StacheDiscountQueryBuilderTest;
+
+class DiscountQueryBuilderTest extends StacheDiscountQueryBuilderTest
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('statamic.cargo.discounts', [
+            'repository' => 'eloquent',
+            'model' => \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountModel::class,
+            'table' => 'cargo_discounts',
+        ]);
+
+        $this->app->bind('cargo.discounts.eloquent.model', function () {
+            return config('statamic.cargo.discounts.model', \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountModel::class);
+        });
+
+        Statamic::repository(
+            \DuncanMcClean\Cargo\Contracts\Discounts\DiscountRepository::class,
+            \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountRepository::class
+        );
+    }
+}

--- a/tests/Discounts/Eloquent/DiscountRepositoryTest.php
+++ b/tests/Discounts/Eloquent/DiscountRepositoryTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Discounts\Eloquent;
+
+use DuncanMcClean\Cargo\Discounts\Eloquent\DiscountModel;
+use DuncanMcClean\Cargo\Facades\Discount;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Statamic;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class DiscountRepositoryTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk, RefreshDatabase;
+
+    protected $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('statamic.cargo.discounts', [
+            'repository' => 'eloquent',
+            'model' => \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountModel::class,
+            'table' => 'cargo_discounts',
+        ]);
+
+        $this->app->bind('cargo.discounts.eloquent.model', function () {
+            return config('statamic.cargo.discounts.model', \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountModel::class);
+        });
+
+        Statamic::repository(
+            \DuncanMcClean\Cargo\Contracts\Discounts\DiscountRepository::class,
+            \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountRepository::class
+        );
+
+        $this->repo = $this->app->make(\DuncanMcClean\Cargo\Contracts\Discounts\DiscountRepository::class);
+    }
+
+    #[Test]
+    public function can_find_discounts()
+    {
+        $model = DiscountModel::create([
+            'handle' => 'summer-sale',
+            'title' => 'Summer Sale',
+            'type' => 'percentage_off',
+            'data' => ['percentage_off' => 10, 'discount_code' => 'SUMMER'],
+        ]);
+
+        $discount = $this->repo->find('summer-sale');
+
+        $this->assertEquals('summer-sale', $discount->handle());
+        $this->assertEquals('Summer Sale', $discount->title());
+        $this->assertEquals('percentage_off', $discount->type());
+        $this->assertEquals(10, $discount->get('percentage_off'));
+        $this->assertEquals('SUMMER', $discount->get('discount_code'));
+    }
+
+    #[Test]
+    public function can_save_a_discount()
+    {
+        $discount = Discount::make()
+            ->handle('summer-sale')
+            ->title('Summer Sale')
+            ->type('percentage_off')
+            ->data(['percentage_off' => 10, 'discount_code' => 'SUMMER']);
+
+        $this->repo->save($discount);
+
+        $this->assertDatabaseHas('cargo_discounts', [
+            'handle' => 'summer-sale',
+            'title' => 'Summer Sale',
+            'type' => 'percentage_off',
+            'data->percentage_off' => 10,
+            'data->discount_code' => 'SUMMER',
+        ]);
+    }
+
+    #[Test]
+    public function can_delete_a_discount()
+    {
+        $discount = Discount::make()
+            ->handle('summer-sale')
+            ->title('Summer Sale')
+            ->type('percentage_off');
+
+        $discount->save();
+
+        $this->repo->delete($discount);
+
+        $this->assertDatabaseMissing('cargo_discounts', [
+            'handle' => 'summer-sale',
+        ]);
+    }
+}

--- a/tests/__fixtures__/migrations/0000_00_00_000000_create_discounts_table.php
+++ b/tests/__fixtures__/migrations/0000_00_00_000000_create_discounts_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('cargo_discounts', function (Blueprint $table) {
+            $table->id();
+            $table->string('handle')->unique();
+            $table->string('title')->nullable();
+            $table->string('type')->nullable();
+            $table->json('data')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('cargo_discounts');
+    }
+};


### PR DESCRIPTION
This PR adds support for storing discounts in the database, matching the existing pattern used by carts and orders.

Discounts can be stored in the database by changing `driver` to `eloquent` in the `config/statamic/cargo.php` config file. To publish migrations and import existing discounts, run:

```
php please cargo:database-discounts
```

Related: #149