### PR TITLE
Support storing tax classes & zones in the database

### DIFF
--- a/config/cargo.php
+++ b/config/cargo.php
@@ -187,6 +187,44 @@ return [
 
         'price_includes_tax' => true,
 
+        /*
+        |--------------------------------------------------------------------------
+        | Tax Classes
+        |--------------------------------------------------------------------------
+        |
+        | By default, tax classes are stored in a flat file. However, it's also
+        | possible to store them in a database by changing the "driver" to "eloquent".
+        |
+        */
+
+        'tax_classes' => [
+            'driver' => 'file',
+
+            'path' => base_path('content/cargo/tax-classes.yaml'),
+
+            // 'model' => \DuncanMcClean\Cargo\Taxes\Eloquent\TaxClassModel::class,
+            // 'table' => 'cargo_tax_classes',
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
+        | Tax Zones
+        |--------------------------------------------------------------------------
+        |
+        | By default, tax zones are stored in a flat file. However, it's also
+        | possible to store them in a database by changing the "driver" to "eloquent".
+        |
+        */
+
+        'tax_zones' => [
+            'driver' => 'file',
+
+            'path' => base_path('content/cargo/tax-zones.yaml'),
+
+            // 'model' => \DuncanMcClean\Cargo\Taxes\Eloquent\TaxZoneModel::class,
+            // 'table' => 'cargo_tax_zones',
+        ],
+
     ],
 
     'shipping' => [

--- a/docs/docs/taxes.md
+++ b/docs/docs/taxes.md
@@ -87,6 +87,28 @@ If needed, you can also display taxes on a more granular level, looping through 
 
 [//]: # (```)
 
+## Database
+
+By default, tax classes and tax zones are stored in flat files. However, you can opt to store them in a database instead.
+
+### Tax Classes
+To move tax classes to the database, run this command:
+
+```
+php please cargo:database-tax-classes
+```
+
+It'll automatically publish database migrations, update your `cargo.php` config file and import existing tax classes into the database.
+
+### Tax Zones
+To move tax zones to the database, run this command:
+
+```
+php please cargo:database-tax-zones
+```
+
+It'll automatically publish database migrations, update your `cargo.php` config file and import existing tax zones into the database.
+
 ## Custom Tax Driver
 If you need to integrate with a third-party taxation system, or just prefer to handle it yourself, you can create a custom tax driver.
 

--- a/src/Commands/DatabaseTaxClasses.php
+++ b/src/Commands/DatabaseTaxClasses.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Commands;
+
+use DuncanMcClean\Cargo\Contracts\Taxes\TaxClass;
+use DuncanMcClean\Cargo\Facades;
+use DuncanMcClean\Cargo\Taxes\Eloquent\TaxClassModel;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Statamic\Console\RunsInPlease;
+use Statamic\Statamic;
+use Stillat\Proteus\Support\Facades\ConfigWriter;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\progress;
+
+class DatabaseTaxClasses extends Command
+{
+    use Concerns\PublishesMigrations, RunsInPlease;
+
+    protected $signature = 'statamic:cargo:database-tax-classes
+        { --import : Whether existing data should be imported }';
+
+    protected $description = 'Migrates tax classes to the database.';
+
+    public function handle(): void
+    {
+        Statamic::repository(
+            \DuncanMcClean\Cargo\Contracts\Taxes\TaxClassRepository::class,
+            \DuncanMcClean\Cargo\Taxes\File\TaxClassRepository::class
+        );
+
+        $this
+            ->publishMigrations()
+            ->runMigrations()
+            ->importTaxClasses()
+            ->updateConfig();
+    }
+
+    private function publishMigrations(): self
+    {
+        $this->publishMigration(
+            stubPath: __DIR__.'/stubs/create_tax_classes_table.php.stub',
+            name: 'create_cargo_tax_classes_table.php',
+            replacements: [
+                'TAX_CLASSES_TABLE' => config('statamic.cargo.taxes.tax_classes.table', 'cargo_tax_classes'),
+            ]
+        );
+
+        return $this;
+    }
+
+    private function runMigrations(): self
+    {
+        Artisan::call('migrate', ['--force' => true], $this->output);
+
+        $this->newLine();
+
+        return $this;
+    }
+
+    private function importTaxClasses(): self
+    {
+        if (
+            ! $this->input->isInteractive()
+            || (! $this->option('import') && ! confirm('Would you like to import existing tax classes?'))
+        ) {
+            return $this;
+        }
+
+        $taxClasses = Facades\TaxClass::all();
+
+        $progress = progress(label: 'Importing tax classes', steps: $taxClasses->count());
+
+        $progress->start();
+
+        $taxClasses->each(function (TaxClass $taxClass) use ($progress) {
+            TaxClassModel::query()->updateOrCreate(
+                ['handle' => $taxClass->handle()],
+                ['data' => $taxClass->fileData()]
+            );
+
+            $progress->advance();
+        });
+
+        $progress->finish();
+
+        $this->components->info('Tax Classes imported successfully.');
+
+        return $this;
+    }
+
+    private function updateConfig(): self
+    {
+        if (config('statamic.cargo.taxes.tax_classes.driver') === 'eloquent') {
+            $this->components->info('Tax Classes repository is already set to `eloquent`.');
+
+            return $this;
+        }
+
+        ConfigWriter::write('statamic.cargo.taxes.tax_classes.driver', 'eloquent');
+
+        $this->components->info('Cargo tax classes driver set to `eloquent`.');
+
+        return $this;
+    }
+}

--- a/src/Commands/DatabaseTaxZones.php
+++ b/src/Commands/DatabaseTaxZones.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Commands;
+
+use DuncanMcClean\Cargo\Contracts\Taxes\TaxZone;
+use DuncanMcClean\Cargo\Facades;
+use DuncanMcClean\Cargo\Taxes\Eloquent\TaxZoneModel;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Statamic\Console\RunsInPlease;
+use Statamic\Statamic;
+use Stillat\Proteus\Support\Facades\ConfigWriter;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\progress;
+
+class DatabaseTaxZones extends Command
+{
+    use Concerns\PublishesMigrations, RunsInPlease;
+
+    protected $signature = 'statamic:cargo:database-tax-zones
+        { --import : Whether existing data should be imported }';
+
+    protected $description = 'Migrates tax zones to the database.';
+
+    public function handle(): void
+    {
+        Statamic::repository(
+            \DuncanMcClean\Cargo\Contracts\Taxes\TaxZoneRepository::class,
+            \DuncanMcClean\Cargo\Taxes\File\TaxZoneRepository::class
+        );
+
+        $this
+            ->publishMigrations()
+            ->runMigrations()
+            ->importTaxZones()
+            ->updateConfig();
+    }
+
+    private function publishMigrations(): self
+    {
+        $this->publishMigration(
+            stubPath: __DIR__.'/stubs/create_tax_zones_table.php.stub',
+            name: 'create_cargo_tax_zones_table.php',
+            replacements: [
+                'TAX_ZONES_TABLE' => config('statamic.cargo.taxes.tax_zones.table', 'cargo_tax_zones'),
+            ]
+        );
+
+        return $this;
+    }
+
+    private function runMigrations(): self
+    {
+        Artisan::call('migrate', ['--force' => true], $this->output);
+
+        $this->newLine();
+
+        return $this;
+    }
+
+    private function importTaxZones(): self
+    {
+        if (
+            ! $this->input->isInteractive()
+            || (! $this->option('import') && ! confirm('Would you like to import existing tax zones?'))
+        ) {
+            return $this;
+        }
+
+        $taxZones = Facades\TaxZone::all();
+
+        $progress = progress(label: 'Importing tax zones', steps: $taxZones->count());
+
+        $progress->start();
+
+        $taxZones->each(function (TaxZone $taxZone) use ($progress) {
+            TaxZoneModel::query()->updateOrCreate(
+                ['handle' => $taxZone->handle()],
+                ['data' => $taxZone->fileData()]
+            );
+
+            $progress->advance();
+        });
+
+        $progress->finish();
+
+        $this->components->info('Tax Zones imported successfully.');
+
+        return $this;
+    }
+
+    private function updateConfig(): self
+    {
+        if (config('statamic.cargo.taxes.tax_zones.driver') === 'eloquent') {
+            $this->components->info('Tax Zones repository is already set to `eloquent`.');
+
+            return $this;
+        }
+
+        ConfigWriter::write('statamic.cargo.taxes.tax_zones.driver', 'eloquent');
+
+        $this->components->info('Cargo tax zones driver set to `eloquent`.');
+
+        return $this;
+    }
+}

--- a/src/Commands/stubs/create_tax_classes_table.php.stub
+++ b/src/Commands/stubs/create_tax_classes_table.php.stub
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('TAX_CLASSES_TABLE', function (Blueprint $table) {
+            $table->string('handle')->primary();
+            $table->json('data')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('TAX_CLASSES_TABLE');
+    }
+};

--- a/src/Commands/stubs/create_tax_zones_table.php.stub
+++ b/src/Commands/stubs/create_tax_zones_table.php.stub
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('TAX_ZONES_TABLE', function (Blueprint $table) {
+            $table->string('handle')->primary();
+            $table->json('data')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('TAX_ZONES_TABLE');
+    }
+};

--- a/src/Facades/TaxClass.php
+++ b/src/Facades/TaxClass.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void delete(string $handle)
  * @method static \Statamic\Fields\Blueprint blueprint()
  *
- * @see \DuncanMcClean\Cargo\Taxes\TaxClassRepository
+ * @see \DuncanMcClean\Cargo\Taxes\File\TaxClassRepository
  */
 class TaxClass extends Facade
 {

--- a/src/Facades/TaxZone.php
+++ b/src/Facades/TaxZone.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void delete(string $handle)
  * @method static \Statamic\Fields\Blueprint blueprint()
  *
- * @see \DuncanMcClean\Cargo\Taxes\TaxZoneRepository
+ * @see \DuncanMcClean\Cargo\Taxes\File\TaxZoneRepository
  */
 class TaxZone extends Facade
 {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -158,8 +158,8 @@ class ServiceProvider extends AddonServiceProvider
             \DuncanMcClean\Cargo\Contracts\Discounts\DiscountRepository::class => \DuncanMcClean\Cargo\Stache\Repositories\DiscountRepository::class,
             \DuncanMcClean\Cargo\Contracts\Orders\OrderRepository::class => \DuncanMcClean\Cargo\Stache\Repositories\OrderRepository::class,
             \DuncanMcClean\Cargo\Contracts\Products\ProductRepository::class => \DuncanMcClean\Cargo\Products\ProductRepository::class,
-            \DuncanMcClean\Cargo\Contracts\Taxes\TaxClassRepository::class => \DuncanMcClean\Cargo\Taxes\TaxClassRepository::class,
-            \DuncanMcClean\Cargo\Contracts\Taxes\TaxZoneRepository::class => \DuncanMcClean\Cargo\Taxes\TaxZoneRepository::class,
+            \DuncanMcClean\Cargo\Contracts\Taxes\TaxClassRepository::class => \DuncanMcClean\Cargo\Taxes\File\TaxClassRepository::class,
+            \DuncanMcClean\Cargo\Contracts\Taxes\TaxZoneRepository::class => \DuncanMcClean\Cargo\Taxes\File\TaxZoneRepository::class,
         ])->each(function ($concrete, $abstract) {
             if (! $this->app->bound($abstract)) {
                 Statamic::repository($abstract, $concrete);
@@ -193,6 +193,20 @@ class ServiceProvider extends AddonServiceProvider
             Statamic::repository(
                 \DuncanMcClean\Cargo\Contracts\Orders\OrderRepository::class,
                 \DuncanMcClean\Cargo\Orders\Eloquent\OrderRepository::class
+            );
+        }
+
+        if (config('statamic.cargo.taxes.tax_classes.driver') === 'eloquent') {
+            Statamic::repository(
+                \DuncanMcClean\Cargo\Contracts\Taxes\TaxClassRepository::class,
+                \DuncanMcClean\Cargo\Taxes\Eloquent\TaxClassRepository::class
+            );
+        }
+
+        if (config('statamic.cargo.taxes.tax_zones.driver') === 'eloquent') {
+            Statamic::repository(
+                \DuncanMcClean\Cargo\Contracts\Taxes\TaxZoneRepository::class,
+                \DuncanMcClean\Cargo\Taxes\Eloquent\TaxZoneRepository::class
             );
         }
 

--- a/src/Taxes/Eloquent/TaxClassModel.php
+++ b/src/Taxes/Eloquent/TaxClassModel.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Taxes\Eloquent;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TaxClassModel extends Model
+{
+    protected $guarded = [];
+
+    public $incrementing = false;
+
+    protected $primaryKey = 'handle';
+
+    protected $keyType = 'string';
+
+    public function getTable(): string
+    {
+        return config('statamic.cargo.taxes.tax_classes.table', 'cargo_tax_classes');
+    }
+
+    public function casts(): array
+    {
+        return [
+            'data' => 'json',
+        ];
+    }
+}

--- a/src/Taxes/Eloquent/TaxClassRepository.php
+++ b/src/Taxes/Eloquent/TaxClassRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Taxes\Eloquent;
+
+use DuncanMcClean\Cargo\Contracts\Taxes\TaxClass;
+use DuncanMcClean\Cargo\Taxes\File\TaxClassRepository as FileRepository;
+use Illuminate\Support\Collection;
+
+class TaxClassRepository extends FileRepository
+{
+    public function all(): Collection
+    {
+        return TaxClassModel::query()->get()->map(function (TaxClassModel $model) {
+            return $this->make()->handle($model->handle)->data($model->data ?? []);
+        });
+    }
+
+    public function find(string $handle): ?TaxClass
+    {
+        $model = TaxClassModel::query()->find($handle);
+
+        if (! $model) {
+            return null;
+        }
+
+        return $this->make()->handle($model->handle)->data($model->data ?? []);
+    }
+
+    public function save(TaxClass $taxClass): void
+    {
+        TaxClassModel::query()->updateOrCreate(
+            ['handle' => $taxClass->handle()],
+            ['data' => $taxClass->fileData()]
+        );
+    }
+
+    public function delete(string $handle): void
+    {
+        TaxClassModel::query()->where('handle', $handle)->delete();
+    }
+}

--- a/src/Taxes/Eloquent/TaxZoneModel.php
+++ b/src/Taxes/Eloquent/TaxZoneModel.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Taxes\Eloquent;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TaxZoneModel extends Model
+{
+    protected $guarded = [];
+
+    public $incrementing = false;
+
+    protected $primaryKey = 'handle';
+
+    protected $keyType = 'string';
+
+    public function getTable(): string
+    {
+        return config('statamic.cargo.taxes.tax_zones.table', 'cargo_tax_zones');
+    }
+
+    public function casts(): array
+    {
+        return [
+            'data' => 'json',
+        ];
+    }
+}

--- a/src/Taxes/Eloquent/TaxZoneRepository.php
+++ b/src/Taxes/Eloquent/TaxZoneRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Taxes\Eloquent;
+
+use DuncanMcClean\Cargo\Contracts\Taxes\TaxZone;
+use DuncanMcClean\Cargo\Taxes\File\TaxZoneRepository as FileRepository;
+use Illuminate\Support\Collection;
+
+class TaxZoneRepository extends FileRepository
+{
+    public function all(): Collection
+    {
+        return TaxZoneModel::query()->get()->map(function (TaxZoneModel $model) {
+            return $this->make()->handle($model->handle)->data($model->data ?? []);
+        });
+    }
+
+    public function find(string $handle): ?TaxZone
+    {
+        $model = TaxZoneModel::query()->find($handle);
+
+        if (! $model) {
+            return null;
+        }
+
+        return $this->make()->handle($model->handle)->data($model->data ?? []);
+    }
+
+    public function save(TaxZone $taxZone): void
+    {
+        TaxZoneModel::query()->updateOrCreate(
+            ['handle' => $taxZone->handle()],
+            ['data' => $taxZone->fileData()]
+        );
+    }
+
+    public function delete(string $handle): void
+    {
+        TaxZoneModel::query()->where('handle', $handle)->delete();
+    }
+}

--- a/src/Taxes/File/TaxClassRepository.php
+++ b/src/Taxes/File/TaxClassRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DuncanMcClean\Cargo\Taxes;
+namespace DuncanMcClean\Cargo\Taxes\File;
 
 use DuncanMcClean\Cargo\Contracts\Taxes\TaxClass;
 use DuncanMcClean\Cargo\Contracts\Taxes\TaxClassRepository as Contract;
@@ -85,9 +85,9 @@ class TaxClassRepository implements Contract
         ]);
     }
 
-    private function getPath(): string
+    protected function getPath(): string
     {
-        return base_path('content/cargo/tax-classes.yaml');
+        return config('statamic.cargo.taxes.tax_classes.path', base_path('content/cargo/tax-classes.yaml'));
     }
 
     public static function bindings(): array

--- a/src/Taxes/File/TaxZoneRepository.php
+++ b/src/Taxes/File/TaxZoneRepository.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DuncanMcClean\Cargo\Taxes;
+namespace DuncanMcClean\Cargo\Taxes\File;
 
 use DuncanMcClean\Cargo\Contracts\Taxes\TaxZone;
 use DuncanMcClean\Cargo\Contracts\Taxes\TaxZoneRepository as Contract;
@@ -150,9 +150,9 @@ class TaxZoneRepository implements Contract
         ]);
     }
 
-    private function getPath(): string
+    protected function getPath(): string
     {
-        return base_path('content/cargo/tax-zones.yaml');
+        return config('statamic.cargo.taxes.tax_zones.path', base_path('content/cargo/tax-zones.yaml'));
     }
 
     public static function bindings(): array

--- a/tests/Taxes/Eloquent/TaxClassTest.php
+++ b/tests/Taxes/Eloquent/TaxClassTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Taxes\Eloquent;
+
+use DuncanMcClean\Cargo\Facades;
+use DuncanMcClean\Cargo\Taxes\Eloquent\TaxClassModel;
+use DuncanMcClean\Cargo\Taxes\TaxClass;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Statamic;
+use Tests\TestCase;
+
+class TaxClassTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Statamic::repository(
+            \DuncanMcClean\Cargo\Contracts\Taxes\TaxClassRepository::class,
+            \DuncanMcClean\Cargo\Taxes\Eloquent\TaxClassRepository::class
+        );
+    }
+
+    #[Test]
+    public function it_can_get_all_tax_classes()
+    {
+        TaxClassModel::query()->create(['handle' => 'standard', 'data' => ['title' => 'Standard Tax']]);
+        TaxClassModel::query()->create(['handle' => 'reduced', 'data' => ['title' => 'Reduced Tax']]);
+
+        $all = Facades\TaxClass::all();
+
+        $this->assertEquals(2, $all->count());
+        $this->assertInstanceOf(Collection::class, $all);
+
+        $this->assertEquals('Standard Tax', $all->first()->get('title'));
+        $this->assertEquals('Reduced Tax', $all->last()->get('title'));
+    }
+
+    #[Test]
+    public function it_can_find_a_tax_class()
+    {
+        TaxClassModel::query()->create(['handle' => 'standard', 'data' => ['title' => 'Standard Tax']]);
+        TaxClassModel::query()->create(['handle' => 'reduced', 'data' => ['title' => 'Reduced Tax']]);
+
+        $taxClass = Facades\TaxClass::find('standard');
+
+        $this->assertInstanceOf(TaxClass::class, $taxClass);
+        $this->assertEquals('standard', $taxClass->handle());
+        $this->assertEquals('Standard Tax', $taxClass->get('title'));
+    }
+
+    #[Test]
+    public function it_can_make_a_tax_class()
+    {
+        $taxClass = Facades\TaxClass::make();
+
+        $this->assertInstanceOf(TaxClass::class, $taxClass);
+    }
+
+    #[Test]
+    public function it_can_save_a_tax_class()
+    {
+        TaxClassModel::query()->create(['handle' => 'standard', 'data' => ['title' => 'Standard Tax']]);
+
+        $taxClass = Facades\TaxClass::make()
+            ->handle('reduced')
+            ->data(['title' => 'Reduced Tax']);
+
+        $save = $taxClass->save();
+
+        $this->assertTrue($save);
+
+        $this->assertDatabaseHas('cargo_tax_classes', ['handle' => 'standard']);
+        $this->assertDatabaseHas('cargo_tax_classes', ['handle' => 'reduced']);
+    }
+
+    #[Test]
+    public function it_can_delete_a_tax_class()
+    {
+        TaxClassModel::query()->create(['handle' => 'standard', 'data' => ['title' => 'Standard Tax']]);
+        TaxClassModel::query()->create(['handle' => 'reduced', 'data' => ['title' => 'Reduced Tax']]);
+
+        $delete = Facades\TaxClass::find('standard')->delete();
+
+        $this->assertTrue($delete);
+
+        $this->assertDatabaseMissing('cargo_tax_classes', ['handle' => 'standard']);
+        $this->assertDatabaseHas('cargo_tax_classes', ['handle' => 'reduced']);
+    }
+
+    #[Test]
+    public function it_handles_tax_classes_with_numerical_handles_correctly()
+    {
+        $taxClass = Facades\TaxClass::make()
+            ->handle('21')
+            ->data(['title' => '21% Tax']);
+
+        $taxClass->save();
+
+        $find = Facades\TaxClass::find('21');
+
+        $this->assertInstanceOf(TaxClass::class, $find);
+        $this->assertSame('21', $find->handle());
+        $this->assertEquals('21% Tax', $find->get('title'));
+
+        $all = Facades\TaxClass::all();
+
+        $this->assertEquals(1, $all->count());
+        $this->assertSame('21', $all->first()->handle());
+
+        $find->set('title', '21% VAT')->save();
+
+        $reloaded = Facades\TaxClass::find('21');
+        $this->assertEquals('21% VAT', $reloaded->get('title'));
+
+        $find->delete();
+
+        $this->assertDatabaseMissing('cargo_tax_classes', ['handle' => '21']);
+    }
+}

--- a/tests/Taxes/Eloquent/TaxZoneTest.php
+++ b/tests/Taxes/Eloquent/TaxZoneTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Taxes\Eloquent;
+
+use DuncanMcClean\Cargo\Facades;
+use DuncanMcClean\Cargo\Taxes\Eloquent\TaxZoneModel;
+use DuncanMcClean\Cargo\Taxes\TaxZone;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Statamic;
+use Tests\TestCase;
+
+class TaxZoneTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Statamic::repository(
+            \DuncanMcClean\Cargo\Contracts\Taxes\TaxZoneRepository::class,
+            \DuncanMcClean\Cargo\Taxes\Eloquent\TaxZoneRepository::class
+        );
+    }
+
+    #[Test]
+    public function it_can_get_all_tax_zones()
+    {
+        TaxZoneModel::query()->create([
+            'handle' => 'uk',
+            'data' => ['title' => 'United Kingdom', 'type' => 'countries', 'countries' => ['GBR'], 'rates' => ['standard' => 20]],
+        ]);
+        TaxZoneModel::query()->create([
+            'handle' => 'eu',
+            'data' => ['title' => 'European Union', 'type' => 'countries', 'countries' => ['FRA', 'DEU'], 'rates' => ['standard' => 20]],
+        ]);
+
+        $all = Facades\TaxZone::all();
+
+        $this->assertEquals(2, $all->count());
+        $this->assertInstanceOf(Collection::class, $all);
+
+        $this->assertEquals('United Kingdom', $all->first()->get('title'));
+        $this->assertEquals('European Union', $all->last()->get('title'));
+    }
+
+    #[Test]
+    public function it_can_find_a_tax_zone()
+    {
+        TaxZoneModel::query()->create([
+            'handle' => 'uk',
+            'data' => ['title' => 'United Kingdom', 'type' => 'countries', 'countries' => ['GBR'], 'rates' => ['standard' => 20]],
+        ]);
+        TaxZoneModel::query()->create([
+            'handle' => 'eu',
+            'data' => ['title' => 'European Union', 'type' => 'countries', 'countries' => ['FRA', 'DEU'], 'rates' => ['standard' => 20]],
+        ]);
+
+        $taxZone = Facades\TaxZone::find('uk');
+
+        $this->assertInstanceOf(TaxZone::class, $taxZone);
+        $this->assertEquals('uk', $taxZone->handle());
+        $this->assertEquals('United Kingdom', $taxZone->get('title'));
+        $this->assertEquals('countries', $taxZone->get('type'));
+        $this->assertEquals(20, $taxZone->rates()->get('standard'));
+    }
+
+    #[Test]
+    public function it_can_make_a_tax_zone()
+    {
+        $taxZone = Facades\TaxZone::make();
+
+        $this->assertInstanceOf(TaxZone::class, $taxZone);
+    }
+
+    #[Test]
+    public function it_can_save_a_tax_zone()
+    {
+        TaxZoneModel::query()->create([
+            'handle' => 'uk',
+            'data' => ['title' => 'United Kingdom', 'type' => 'countries', 'countries' => ['GBR'], 'rates' => ['standard' => 20]],
+        ]);
+
+        $taxZone = Facades\TaxZone::make()
+            ->handle('eu')
+            ->data([
+                'title' => 'European Union',
+                'type' => 'countries',
+                'countries' => ['FRA', 'DEU'],
+                'rates' => ['standard' => 20],
+            ]);
+
+        $save = $taxZone->save();
+
+        $this->assertTrue($save);
+
+        $this->assertDatabaseHas('cargo_tax_zones', ['handle' => 'uk']);
+        $this->assertDatabaseHas('cargo_tax_zones', ['handle' => 'eu']);
+    }
+
+    #[Test]
+    public function it_can_delete_a_tax_zone()
+    {
+        TaxZoneModel::query()->create([
+            'handle' => 'uk',
+            'data' => ['title' => 'United Kingdom', 'type' => 'countries', 'countries' => ['GBR'], 'rates' => ['standard' => 20]],
+        ]);
+        TaxZoneModel::query()->create([
+            'handle' => 'eu',
+            'data' => ['title' => 'European Union', 'type' => 'countries', 'countries' => ['FRA', 'DEU'], 'rates' => ['standard' => 20]],
+        ]);
+
+        $delete = Facades\TaxZone::find('uk')->delete();
+
+        $this->assertTrue($delete);
+
+        $this->assertDatabaseMissing('cargo_tax_zones', ['handle' => 'uk']);
+        $this->assertDatabaseHas('cargo_tax_zones', ['handle' => 'eu']);
+    }
+
+    #[Test]
+    public function it_handles_tax_zones_with_numerical_tax_class_handles_correctly()
+    {
+        TaxZoneModel::query()->create([
+            'handle' => 'uk',
+            'data' => [
+                'title' => 'United Kingdom',
+                'type' => 'countries',
+                'countries' => ['GBR'],
+                'rates' => [
+                    'standard' => 20,
+                    21 => 15,
+                ],
+            ],
+        ]);
+
+        $taxZone = Facades\TaxZone::find('uk');
+        $rates = $taxZone->rates();
+
+        $this->assertEquals(20, $rates->get('standard'));
+        $this->assertEquals(15, $rates->get('21'));
+    }
+
+    #[Test]
+    public function it_handles_tax_zones_with_numerical_handles_correctly()
+    {
+        $taxZone = Facades\TaxZone::make()
+            ->handle('21')
+            ->data([
+                'title' => '21% VAT Zone',
+                'type' => 'everywhere',
+                'rates' => ['standard' => 21],
+            ]);
+
+        $taxZone->save();
+
+        $find = Facades\TaxZone::find('21');
+
+        $this->assertInstanceOf(TaxZone::class, $find);
+        $this->assertSame('21', $find->handle());
+        $this->assertEquals('21% VAT Zone', $find->get('title'));
+
+        $all = Facades\TaxZone::all();
+
+        $this->assertEquals(1, $all->count());
+        $this->assertSame('21', $all->first()->handle());
+
+        $find->set('title', '21% VAT')->save();
+
+        $reloaded = Facades\TaxZone::find('21');
+        $this->assertEquals('21% VAT', $reloaded->get('title'));
+
+        $find->delete();
+
+        $this->assertDatabaseMissing('cargo_tax_zones', ['handle' => '21']);
+    }
+}

--- a/tests/__fixtures__/migrations/0000_00_00_000000_create_tax_classes_table.php
+++ b/tests/__fixtures__/migrations/0000_00_00_000000_create_tax_classes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('cargo_tax_classes', function (Blueprint $table) {
+            $table->string('handle')->primary();
+            $table->json('data')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('cargo_tax_classes');
+    }
+};

--- a/tests/__fixtures__/migrations/0000_00_00_000000_create_tax_zones_table.php
+++ b/tests/__fixtures__/migrations/0000_00_00_000000_create_tax_zones_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('cargo_tax_zones', function (Blueprint $table) {
+            $table->string('handle')->primary();
+            $table->json('data')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('cargo_tax_zones');
+    }
+};


### PR DESCRIPTION
This PR adds support for storing tax classes and tax rates in the database.

You may run the following commands to publish database migrations, update the config, and import existing data for tax classes and zones respectively:

- `php please cargo:database-tax-classes`
- `php please cargo:database-tax-zones`

Related: #149