### PR TITLE
Add `cargo:database` command

### DIFF
--- a/docs/docs/discounts.md
+++ b/docs/docs/discounts.md
@@ -20,10 +20,31 @@ You can create discounts in the Control Panel.
 
 Discounts can be configured using various conditions and limitations. Most of the options are pretty self-explanatory:
 
-
 ![Discount Create Form](/images/discount-publish-form.png)
 
 Cargo supports "Amount off" and "Percentage off" discount types out-of-the-box, with more on the way. If you need to, you can also [build your own discount type](#building-your-own-discount-type).
+
+## Redeem discount codes
+You can redeem discount codes using the `{{ cart:update }}` form. Simply provide a `discount_code` input so the customer can enter their discount code.
+
+::tabs  
+::tab antlers
+```antlers  
+{{ cart:update }}    
+    <input type="text" name="discount_code" value="{{ discount_code }}" required>    
+	<button>Update</button>  
+{{ /cart:update }}  
+```  
+::tab blade
+```blade  
+<s:cart:update>    
+    <input type="text" name="discount_code" value="{{ $discount_code }}" required>
+	<button>Update</button>  
+</s:cart:update>  
+```  
+::
+
+When the customer attempts to use an invalid discount code, you use Statamic's [`{{ get_errors }}`](https://statamic.dev/tags/get_errors) tag to display the validation error.
 
 ## Storage
 Out of the box, discounts are stored as YAML files in the `content/cargo/discounts` directory. If you wish, you can change the directory in the `cargo.php` config file:
@@ -54,28 +75,6 @@ If needed, you can customise the eloquent model Cargo uses by updating the `mode
 :::tip warning
 Make sure you have a backup strategy in place before moving discounts to the database, in case the worst happens. Both [Laravel Forge](https://forge.laravel.com/docs/servers/backups) and [Ploi](https://ploi.io/features/database-backups) have built-in solutions for database backups.
 :::
-
-## Redeem discount codes
-You can redeem discount codes using the `{{ cart:update }}` form. Simply provide a `discount_code` input so the customer can enter their discount code.
-
-::tabs  
-::tab antlers  
-```antlers  
-{{ cart:update }}    
-    <input type="text" name="discount_code" value="{{ discount_code }}" required>    
-	<button>Update</button>  
-{{ /cart:update }}  
-```  
-::tab blade  
-```blade  
-<s:cart:update>    
-    <input type="text" name="discount_code" value="{{ $discount_code }}" required>
-	<button>Update</button>  
-</s:cart:update>  
-```  
-::
-
-When the customer attempts to use an invalid discount code, you use Statamic's [`{{ get_errors }}`](https://statamic.dev/tags/get_errors) tag to display the validation error. 
 
 ## Building your own discount type
 If you need to support some kind of discount that Cargo doesn't already support, you can build your own discount type.

--- a/docs/knowledge-base/guides/database.md
+++ b/docs/knowledge-base/guides/database.md
@@ -1,0 +1,48 @@
+---
+title: Storing data in a database
+description: "Out of the box, Cargo stores all of its data in flat files. However, you can opt to store some (or all) of your data in a traditional database instead."
+---
+
+Out of the box, Cargo stores all of its data in flat files. However, you can opt to store some (or all) of your data in a traditional database instead.
+
+## Migrating
+
+To get started, run the following command:
+
+```
+php please cargo:database
+```
+
+You'll be presented with a list of repositories to choose from. Select the ones you'd like to migrate, and Cargo will publish the necessary migrations, run them, and update your config file.
+
+If you'd like to migrate all repositories at once, you may use the `--all` flag:
+
+```
+php please cargo:database --all
+```
+
+The available repositories are:
+
+| Repository  | Config Key                                | Docs                                 |
+|-------------|-------------------------------------------|--------------------------------------|
+| Carts       | `statamic.cargo.carts.driver`             | [Carts](/docs/carts#storage)         |
+| Discounts   | `statamic.cargo.discounts.driver`         | [Discounts](/docs/discounts#storage) |
+| Orders      | `statamic.cargo.orders.driver`            | [Orders](/docs/orders#storage)       |
+| Tax Classes | `statamic.cargo.taxes.tax_classes.driver` | [Taxes](/docs/taxes#database)        |
+| Tax Zones   | `statamic.cargo.taxes.tax_zones.driver`   | [Taxes](/docs/taxes#database)        |
+
+Products are stored as entries, so you can use the official [Eloquent Driver](https://statamic.dev/knowledge-base/tips/storing-content-in-a-database) to move them to the database. 
+
+Customers are Statamic users, so can be moved to the database by following [this guide on the Statamic docs](https://statamic.dev/knowledge-base/tips/storing-users-in-a-database).
+
+## Importing Existing Data
+
+During the migration process, you'll be asked if you'd like to import existing data from flat files into the database. If you'd prefer to skip the prompt, you can pass the `--import` flag:
+
+```
+php please cargo:database --all --import
+```
+
+## Customizing Models & Tables
+
+Each repository allows you to customize the Eloquent model and database table used. You can do this by updating the relevant keys in your `cargo.php` config file. See the individual docs pages for more details.

--- a/src/Commands/Database.php
+++ b/src/Commands/Database.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Statamic\Console\RunsInPlease;
+
+use function Laravel\Prompts\multiselect;
+
+class Database extends Command
+{
+    use RunsInPlease;
+
+    protected $signature = 'statamic:cargo:database
+        { --all : Migrates all repositories to the database }
+        { --import : Whether existing data should be imported }';
+
+    protected $description = 'Migrates Cargo repositories to the database.';
+
+    public function handle(): void
+    {
+        $repositories = $this->repositories();
+
+        foreach ($repositories as $repository) {
+            $command = 'statamic:cargo:database-'.str_replace('_', '-', $repository);
+
+            $this->call($command, [
+                '--import' => $this->option('import'),
+            ]);
+
+            $this->newLine();
+        }
+    }
+
+    private function repositories(): array
+    {
+        if ($this->option('all')) {
+            return $this->allRepositories()->keys()->all();
+        }
+
+        return multiselect(
+            label: 'Which repositories would you like to migrate?',
+            options: $this->allRepositories()
+                ->reject(fn ($value, $key) => $this->repositoryHasBeenMigrated($key))
+                ->all(),
+            validate: fn (array $values) => count($values) === 0
+                ? 'You must select at least one repository.'
+                : null,
+            hint: 'You can always migrate other repositories later.'
+        );
+    }
+
+    private function allRepositories(): Collection
+    {
+        return collect([
+            'carts' => 'Carts',
+            'discounts' => 'Discounts',
+            'orders' => 'Orders',
+            'tax_classes' => 'Tax Classes',
+            'tax_zones' => 'Tax Zones',
+        ]);
+    }
+
+    private function repositoryHasBeenMigrated(string $repository): bool
+    {
+        return match ($repository) {
+            'carts' => config('statamic.cargo.carts.driver') === 'eloquent',
+            'discounts' => config('statamic.cargo.discounts.driver') === 'eloquent',
+            'orders' => config('statamic.cargo.orders.driver') === 'eloquent',
+            'tax_classes' => config('statamic.cargo.taxes.tax_classes.driver') === 'eloquent',
+            'tax_zones' => config('statamic.cargo.taxes.tax_zones.driver') === 'eloquent',
+            default => false,
+        };
+    }
+}

--- a/src/Commands/DatabaseCarts.php
+++ b/src/Commands/DatabaseCarts.php
@@ -88,6 +88,12 @@ class DatabaseCarts extends Command
 
         $query = Cart::query();
 
+        if ($query->count() === 0) {
+            $this->components->warn('Nothing to import.');
+
+            return $this;
+        }
+
         $progress = progress(label: 'Importing carts', steps: $query->count());
 
         $progress->start();

--- a/src/Commands/DatabaseDiscounts.php
+++ b/src/Commands/DatabaseDiscounts.php
@@ -74,6 +74,12 @@ class DatabaseDiscounts extends Command
 
         $query = Discount::query();
 
+        if ($query->count() === 0) {
+            $this->components->warn('Nothing to import.');
+
+            return $this;
+        }
+
         $progress = progress(label: 'Importing discounts', steps: $query->count());
 
         $progress->start();

--- a/src/Commands/DatabaseOrders.php
+++ b/src/Commands/DatabaseOrders.php
@@ -88,6 +88,12 @@ class DatabaseOrders extends Command
 
         $query = Order::query();
 
+        if ($query->count() === 0) {
+            $this->components->warn('Nothing to import.');
+
+            return $this;
+        }
+
         $progress = progress(label: 'Importing orders', steps: $query->count());
 
         $progress->start();

--- a/src/Commands/DatabaseTaxClasses.php
+++ b/src/Commands/DatabaseTaxClasses.php
@@ -70,6 +70,12 @@ class DatabaseTaxClasses extends Command
 
         $taxClasses = Facades\TaxClass::all();
 
+        if ($taxClasses->isEmpty()) {
+            $this->components->warn('Nothing to import.');
+
+            return $this;
+        }
+
         $progress = progress(label: 'Importing tax classes', steps: $taxClasses->count());
 
         $progress->start();

--- a/src/Commands/DatabaseTaxZones.php
+++ b/src/Commands/DatabaseTaxZones.php
@@ -70,6 +70,12 @@ class DatabaseTaxZones extends Command
 
         $taxZones = Facades\TaxZone::all();
 
+        if ($taxZones->isEmpty()) {
+            $this->components->warn('Nothing to import.');
+
+            return $this;
+        }
+
         $progress = progress(label: 'Importing tax zones', steps: $taxZones->count());
 
         $progress->start();


### PR DESCRIPTION
This pull request adds a `php please cargo:database` command, making it really easy to switch multiple repositories to the database at once.

Goes alongside #184 and #185 which add database support for more repos.