### PR TITLE
Add primary keys to UUID columns in migration stubs

### DIFF
--- a/src/Commands/stubs/create_cart_line_items_table.php.stub
+++ b/src/Commands/stubs/create_cart_line_items_table.php.stub
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('CART_LINE_ITEMS_TABLE', function (Blueprint $table) {
-            $table->uuid('id');
+            $table->uuid('id')->primary();
             $table->string('cart_id')->index();
             $table->string('product');
             $table->string('variant')->nullable();

--- a/src/Commands/stubs/create_carts_table.php.stub
+++ b/src/Commands/stubs/create_carts_table.php.stub
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::create('CARTS_TABLE', function (Blueprint $table) {
-            $table->uuid('id');
+            $table->uuid('id')->primary();
             $table->string('site');
             $table->string('customer')->nullable();
             $table->bigInteger('grand_total');

--- a/src/Commands/stubs/create_order_line_items_table.php.stub
+++ b/src/Commands/stubs/create_order_line_items_table.php.stub
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('ORDER_LINE_ITEMS_TABLE', function (Blueprint $table) {
-            $table->uuid('id');
+            $table->uuid('id')->primary();
             $table->string('order_id')->index();
             $table->string('product');
             $table->string('variant')->nullable();

--- a/tests/__fixtures__/migrations/0000_00_00_000000_create_cart_line_items_table.php
+++ b/tests/__fixtures__/migrations/0000_00_00_000000_create_cart_line_items_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('cargo_cart_line_items', function (Blueprint $table) {
-            $table->uuid('id');
+            $table->uuid('id')->primary();
             $table->string('cart_id')->index();
             $table->string('product');
             $table->string('variant')->nullable();

--- a/tests/__fixtures__/migrations/0000_00_00_000000_create_carts_table.php
+++ b/tests/__fixtures__/migrations/0000_00_00_000000_create_carts_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::create('cargo_carts', function (Blueprint $table) {
-            $table->uuid('id');
+            $table->uuid('id')->primary();
             $table->string('site');
             $table->string('customer')->nullable();
             $table->bigInteger('grand_total');

--- a/tests/__fixtures__/migrations/0000_00_00_000000_create_order_line_items_table.php
+++ b/tests/__fixtures__/migrations/0000_00_00_000000_create_order_line_items_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('cargo_order_line_items', function (Blueprint $table) {
-            $table->uuid('id');
+            $table->uuid('id')->primary();
             $table->string('order_id')->index();
             $table->string('product');
             $table->string('variant')->nullable();


### PR DESCRIPTION
This pull request fixes an issue where the `cargo_carts`, `cargo_cart_line_items`, and `cargo_order_line_items` tables were missing primary keys.

This was happening because the migration stubs used `$table->uuid('id')` without `->primary()`, resulting in no primary key or index on the `id` column.

This PR fixes it by adding `->primary()` to the UUID columns in the affected migration stubs and test fixtures.

Related: #187