### PR TITLE
Fix Eloquent tax repositories losing handle-based keys

### DIFF
--- a/src/Taxes/Eloquent/TaxClassRepository.php
+++ b/src/Taxes/Eloquent/TaxClassRepository.php
@@ -10,8 +10,8 @@ class TaxClassRepository extends FileRepository
 {
     public function all(): Collection
     {
-        return TaxClassModel::query()->get()->map(function (TaxClassModel $model) {
-            return $this->make()->handle($model->handle)->data($model->data ?? []);
+        return TaxClassModel::query()->get()->mapWithKeys(function (TaxClassModel $model) {
+            return [$model->handle => $this->make()->handle($model->handle)->data($model->data ?? [])];
         });
     }
 

--- a/src/Taxes/Eloquent/TaxZoneRepository.php
+++ b/src/Taxes/Eloquent/TaxZoneRepository.php
@@ -10,8 +10,8 @@ class TaxZoneRepository extends FileRepository
 {
     public function all(): Collection
     {
-        return TaxZoneModel::query()->get()->map(function (TaxZoneModel $model) {
-            return $this->make()->handle($model->handle)->data($model->data ?? []);
+        return TaxZoneModel::query()->get()->mapWithKeys(function (TaxZoneModel $model) {
+            return [$model->handle => $this->make()->handle($model->handle)->data($model->data ?? [])];
         });
     }
 


### PR DESCRIPTION
This pull request fixes an issue where `DefaultTaxDriver` crashes with `Call to a member function get() on null` when using the Eloquent tax zones driver.

This was happening because the Eloquent `TaxZoneRepository::all()` used `map()` which produced numeric keys (`0, 1, ...`), while the file driver preserves handle-based keys. `DefaultTaxDriver::getBreakdown()` uses those keys to look up tax zones via `TaxZoneFacade::find()`, so `find(0)` returned `null`.

This PR fixes it by using `mapWithKeys` to preserve the handle as the collection key, matching the file driver's behavior. The same fix has been applied to `TaxClassRepository` as it had the same pattern.

Fixes #187