### PR TITLE
Fix race condition where Stripe webhook is consumed before order exists

### DIFF
--- a/src/Orders/Actions/CreateOrderFromCart.php
+++ b/src/Orders/Actions/CreateOrderFromCart.php
@@ -50,6 +50,7 @@ class CreateOrderFromCart
             } else {
                 $paymentGateway->process($order);
                 $order->set('payment_gateway', $paymentGateway::handle())->save();
+                $paymentGateway->afterProcess($order);
             }
 
             app(UpdateStock::class)->handle($order);

--- a/src/Payments/Gateways/PaymentGateway.php
+++ b/src/Payments/Gateways/PaymentGateway.php
@@ -29,6 +29,13 @@ abstract class PaymentGateway
 
     abstract public function process(Order $order): void;
 
+    /**
+     * Called by CreateOrderFromCart immediately after process(). Override in gateway
+     * subclasses to handle any post-creation status checks, such as closing the race
+     * condition where a webhook arrives and is acknowledged before the order exists.
+     */
+    public function afterProcess(Order $order): void {}
+
     abstract public function capture(Order $order): void;
 
     abstract public function cancel(Cart $cart): void;

--- a/src/Payments/Gateways/Stripe.php
+++ b/src/Payments/Gateways/Stripe.php
@@ -96,6 +96,31 @@ class Stripe extends PaymentGateway
         ]);
     }
 
+    /**
+     * Close the race condition between the checkout redirect and Stripe's webhooks.
+     *
+     * When capture_method is manual, Stripe fires payment_intent.amount_capturable_updated
+     * almost immediately after the customer confirms payment on the Stripe-hosted page.
+     * In practice this webhook arrives at the endpoint before CreateOrderFromCart has
+     * finished persisting the order. The webhook handler finds no order, acknowledges
+     * the request, and Stripe marks it complete. It will never retry.
+     *
+     * By checking the PaymentIntent status synchronously here we close that window: if
+     * payment has already been authorised or captured by the time we reach this point,
+     * we transition the order status immediately rather than waiting for a webhook that
+     * may have already been consumed.
+     */
+    public function afterProcess(Order $order): void
+    {
+        $paymentIntent = PaymentIntent::retrieve($order->get('stripe_payment_intent'));
+
+        if ($paymentIntent->status === PaymentIntent::STATUS_SUCCEEDED) {
+            $order->status(OrderStatus::PaymentReceived)->save();
+        } elseif ($paymentIntent->status === PaymentIntent::STATUS_REQUIRES_CAPTURE) {
+            $this->capture($order);
+        }
+    }
+
     public function capture(Order $order): void
     {
         $paymentIntent = PaymentIntent::retrieve($order->get('stripe_payment_intent'));

--- a/tests/Payments/StripeTest.php
+++ b/tests/Payments/StripeTest.php
@@ -372,6 +372,67 @@ class StripeTest extends TestCase
     }
 
     #[Test]
+    public function it_transitions_order_to_payment_received_when_payment_intent_has_already_succeeded_at_process_time()
+    {
+        $stripePaymentIntent = PaymentIntent::create([
+            'amount' => 1000,
+            'currency' => 'gbp',
+            'payment_method_types' => ['card'],
+        ]);
+
+        $stripePaymentIntent->confirm(['payment_method' => 'pm_card_visa']);
+
+        $order = $this->makeOrder();
+        $order->set('stripe_payment_intent', $stripePaymentIntent->id)->save();
+
+        (new Stripe)->afterProcess($order);
+
+        $order->fresh();
+        $this->assertEquals('payment_received', $order->status()->value);
+    }
+
+    #[Test]
+    public function it_captures_and_transitions_order_when_payment_intent_requires_capture_at_process_time()
+    {
+        $stripePaymentIntent = PaymentIntent::create([
+            'amount' => 1000,
+            'currency' => 'gbp',
+            'payment_method_types' => ['card'],
+            'capture_method' => 'manual',
+        ]);
+
+        $stripePaymentIntent->confirm(['payment_method' => 'pm_card_visa']);
+
+        $order = $this->makeOrder();
+        $order->set('stripe_payment_intent', $stripePaymentIntent->id)->save();
+
+        (new Stripe)->afterProcess($order);
+
+        $stripePaymentIntent = PaymentIntent::retrieve($stripePaymentIntent->id);
+        $this->assertEquals('succeeded', $stripePaymentIntent->status);
+
+        $order->fresh();
+        $this->assertEquals('payment_received', $order->status()->value);
+    }
+
+    #[Test]
+    public function it_does_nothing_in_after_process_when_payment_intent_is_still_pending()
+    {
+        $stripePaymentIntent = PaymentIntent::create([
+            'amount' => 1000,
+            'currency' => 'gbp',
+        ]);
+
+        $order = $this->makeOrder();
+        $order->set('stripe_payment_intent', $stripePaymentIntent->id)->save();
+
+        (new Stripe)->afterProcess($order);
+
+        $order->fresh();
+        $this->assertEquals('payment_pending', $order->status()->value);
+    }
+
+    #[Test]
     public function it_refunds_a_payment()
     {
         $stripePaymentIntent = PaymentIntent::create([


### PR DESCRIPTION
## What this fixes

Closes #190.

When `capture_method` is manual, Stripe fires `payment_intent.amount_capturable_updated` almost immediately after the customer confirms payment on the Stripe-hosted page. In practice this event arrives at the webhook endpoint before `CreateOrderFromCart` has finished creating and persisting the order.

The webhook handler (`Stripe::webhook()`) queries for an order by PaymentIntent ID. When it finds none, it returns `200` and Stripe marks the event as delivered. It will never retry. The `CreateOrderFromCart` redirect handler then creates the order a moment later, but the order is permanently stuck at `payment_pending` with no further events to advance it.

The only resolution without this fix is manual staff intervention per affected order.

## Approach

The fix adds an `afterProcess(Order $order): void` hook to the `PaymentGateway` base class with a no-op default implementation. `CreateOrderFromCart` calls it immediately after `process()` and the `payment_gateway` field is saved.

The `Stripe` gateway implements `afterProcess()` to retrieve the PaymentIntent synchronously and transition the order if it has already reached `requires_capture` or `succeeded` by the time the order is created. This closes the window between order creation and webhook delivery.

The hook is intentionally placed on the base class rather than being Stripe-specific so that other gateway implementations can handle similar race conditions in future without changes to `CreateOrderFromCart`.

## Changes

- `PaymentGateway`: adds `afterProcess(Order $order): void` with a no-op default.
- `Stripe`: implements `afterProcess()` to check PaymentIntent status and transition the order if payment has already been authorised or captured.
- `CreateOrderFromCart`: calls `$paymentGateway->afterProcess($order)` after `process()`.
- `StripeTest`: adds three tests covering the race condition scenarios (already succeeded, requires capture, still pending).