### PR TITLE
Fix discount not applied to tax calculation and Mollie line items

### DIFF
--- a/src/Cart/Calculator/CalculateTaxes.php
+++ b/src/Cart/Calculator/CalculateTaxes.php
@@ -20,8 +20,8 @@ class CalculateTaxes
         $cart->lineItems()->each(function (LineItem $lineItem) use ($cart, &$taxBreakdowns) {
             $lineItemTotal = $lineItem->total();
 
-            if ($lineItem->get('discount_amount')) {
-                $lineItemTotal -= $lineItem->get('discount_amount');
+            if ($lineItem->discountTotal()) {
+                $lineItemTotal -= $lineItem->discountTotal();
             }
 
             $taxBreakdown = app(TaxDriver::class)

--- a/src/Payments/Gateways/Mollie.php
+++ b/src/Payments/Gateways/Mollie.php
@@ -68,15 +68,16 @@ class Mollie extends PaymentGateway
                 ->map(function (LineItem $lineItem) use ($cart) {
                     // Mollie expects the unit price to include taxes. However, we only apply taxes to the line item total.
                     // So, we need to do some calculations to figure out what the unit price would be including tax.
-                    $unitPrice = ($lineItem->total() + $lineItem->get('discount_amount', 0)) / $lineItem->quantity();
+                    $discountAmount = $lineItem->discountTotal() ?? 0;
+                    $unitPrice = ($lineItem->total() + $discountAmount) / $lineItem->quantity();
 
                     return [
                         'type' => $lineItem->product()->get('type', 'physical'),
                         'description' => $lineItem->product()->get('title'),
                         'quantity' => $lineItem->quantity(),
                         'unitPrice' => $this->formatAmount(site: $cart->site(), amount: $unitPrice),
-                        'discountAmount' => $lineItem->has('discount_amount')
-                            ? $this->formatAmount(site: $cart->site(), amount: $lineItem->get('discount_amount'))
+                        'discountAmount' => $discountAmount > 0
+                            ? $this->formatAmount(site: $cart->site(), amount: $discountAmount)
                             : null,
                         'totalAmount' => $this->formatAmount(site: $cart->site(), amount: $lineItem->total()),
                         'vatRate' => number_format(collect($lineItem->get('tax_breakdown'))->sum('rate'), 2, '.', ''),

--- a/tests/Cart/Calculator/CalculateTaxesTest.php
+++ b/tests/Cart/Calculator/CalculateTaxesTest.php
@@ -210,7 +210,7 @@ class CalculateTaxesTest extends TestCase
 
         $cart = Cart::make()
             ->lineItems([
-                ['id' => 'one', 'product' => $product->id(), 'quantity' => 1, 'total' => 2500, 'discount_amount' => 500],
+                ['id' => 'one', 'product' => $product->id(), 'quantity' => 1, 'total' => 2500, 'discount_total' => 500],
             ])
             ->data([
                 'shipping_address' => [

--- a/tests/Payments/MollieTest.php
+++ b/tests/Payments/MollieTest.php
@@ -131,7 +131,7 @@ class MollieTest extends TestCase
                 [
                     'product' => 'product-id',
                     'quantity' => 1,
-                    'discount_amount' => 100,
+                    'discount_total' => 100,
                     'unit_price' => 1000,
                     'sub_total' => 1000,
                     'tax_total' => 150,


### PR DESCRIPTION
## Summary

`ApplyDiscounts` stores the line item discount via `$lineItem->discountTotal()`, but both `CalculateTaxes` and the Mollie payment gateway read a non-existent `discount_amount` data field via `$lineItem->get('discount_amount')`. This caused:

- **Taxes calculated on pre-discount amounts** — `CalculateTaxes` never subtracted the discount before computing tax, since `$lineItem->get('discount_amount')` always returned null
- **Mollie payments rejected with discount codes** — the order `amount` (which correctly includes the discount via `grandTotal()`) didn't match the sum of line `totalAmount` values (which didn't include the discount). Mollie also rejected the `vatAmount` since it was computed on the pre-discount total

### Fix

Replace `$lineItem->get('discount_amount')` with `$lineItem->discountTotal()` in both files:

- `src/Cart/Calculator/CalculateTaxes.php`
- `src/Payments/Gateways/Mollie.php`

## Steps to reproduce

1. Create a discount code (e.g. 100€ off)
2. Add a product to cart and apply the discount
3. Proceed to checkout with Mollie as payment gateway
4. Mollie rejects with: _"The 'amount' field is off"_ or _"The 'vatAmount' field is off"_

Without a discount code, payments work fine because `totalAmount` and `vatAmount` are both consistently based on the full price.