### PR TITLE
Fix potential race condition between webhook and order save

### DIFF
--- a/src/Fieldtypes/LineItems.php
+++ b/src/Fieldtypes/LineItems.php
@@ -2,7 +2,6 @@
 
 namespace DuncanMcClean\Cargo\Fieldtypes;
 
-use Illuminate\Support\Str;
 use Statamic\Fields\Fieldtype;
 
 class LineItems extends Fieldtype
@@ -16,6 +15,6 @@ class LineItems extends Fieldtype
 
     public function preProcessIndex($data): string
     {
-        return $data->count().' '.Str::plural('line item', $data->count());
+        return trans_choice('{1} :count line item|[2,*] :count line items', $data->count());
     }
 }

--- a/src/Orders/Actions/CreateOrderFromCart.php
+++ b/src/Orders/Actions/CreateOrderFromCart.php
@@ -48,8 +48,8 @@ class CreateOrderFromCart
             if ($order->isFree()) {
                 $order->status(OrderStatus::PaymentReceived)->save();
             } else {
-                $paymentGateway->process($order);
                 $order->set('payment_gateway', $paymentGateway::handle())->save();
+                $paymentGateway->process($order);
             }
 
             app(UpdateStock::class)->handle($order);

--- a/tests/CheckoutTest.php
+++ b/tests/CheckoutTest.php
@@ -296,6 +296,16 @@ class CheckoutTest extends TestCase
         app(CreateOrderFromCart::class)->handle($cart, new FakePaymentGateway);
     }
 
+    #[Test]
+    public function order_status_is_not_overwritten_when_webhook_fires_during_process()
+    {
+        $cart = $this->makeCart();
+
+        $order = app(CreateOrderFromCart::class)->handle($cart, new WebhookRacingPaymentGateway);
+
+        $this->assertEquals(OrderStatus::PaymentReceived, $order->fresh()->status());
+    }
+
     private function makeCart(array $data = [])
     {
         $collection = tap(Collection::make('products'))->save();
@@ -358,6 +368,45 @@ class FakePaymentGateway extends PaymentGateway
     {
         //
 
+        return response();
+    }
+
+    public function refund(Order $order, int $amount): void
+    {
+        //
+    }
+}
+
+class WebhookRacingPaymentGateway extends PaymentGateway
+{
+    public static $handle = 'webhook_racing';
+
+    public function setup(\DuncanMcClean\Cargo\Contracts\Cart\Cart $cart): array
+    {
+        return [];
+    }
+
+    public function process(Order $order): void
+    {
+        // Simulate the webhook arriving during process() and updating the order
+        // status via a separate object instance, like Stripe's webhook would in
+        // a separate HTTP request (especially with the Eloquent driver).
+        $webhookOrder = clone $order;
+        $webhookOrder->status(OrderStatus::PaymentReceived)->save();
+    }
+
+    public function capture(Order $order): void
+    {
+        //
+    }
+
+    public function cancel(\DuncanMcClean\Cargo\Contracts\Cart\Cart $cart): void
+    {
+        //
+    }
+
+    public function webhook(Request $request): Response
+    {
         return response();
     }
 


### PR DESCRIPTION
This pull request fixes a potential issue where a payment gateway webhook could update an order's status (eg. to `payment_received`), only for `CreateOrderFromCart` to overwrite it back to `payment_pending` moments later.

This was happening because `process()` was called before the `payment_gateway` field was saved. Since `process()` makes an external API call (eg. to Stripe), there's a window where a webhook can arrive, find the order, and update its status. The subsequent `save()` then writes the stale in-memory status back to the database, overwriting the webhook's update.

This PR fixes it by swapping the order of operations — saving the `payment_gateway` field first, then calling `process()`. Since there's no `save()` after `process()`, the webhook's status change can no longer be overwritten.

May fix #190