### PR TITLE
Make it possible to customise Stripe & Mollie payment descriptions

### DIFF
--- a/docs/docs/payment-gateways.md
+++ b/docs/docs/payment-gateways.md
@@ -302,6 +302,18 @@ For additional security, we recommend copying the "Webhook Secret" into your `.e
 STRIPE_WEBHOOK_SECRET=whsec_...
 ```
 
+### Payment Description
+By default, the payment description will be `Order #1234`. If necessary, you can customize this by calling the `Stripe::paymentDescription()` hook in your `AppServiceProvider`:
+
+```php
+use DuncanMcClean\Cargo\Contracts\Orders\Order;
+use DuncanMcClean\Cargo\Payments\Gateways\Stripe;
+
+Stripe::paymentDescription(function (Order $order) {
+    return "Acme Store - {$order->orderNumber()}";
+});
+```
+
 ## Mollie
 ### Payment Form
 :::tip note
@@ -335,6 +347,18 @@ However, when you're developing locally, your local development site won't be ac
 You can workaround this by setting up a tunneling service, like [Expose](https://expose.dev) or [Ngrok](https://ngrok.com), which will provide you with a publicly accessible URL that Mollie can use to talk with your local dev site.
 
 You will need to update the `APP_URL` key in your `.env` while your tunnel is active, so the gateway points towards the tunnel.
+
+### Payment Description
+By default, the payment description will be `Order #1234`. If necessary, you can customize this by calling the `Mollie::paymentDescription()` hook in your `AppServiceProvider`:
+
+```php
+use DuncanMcClean\Cargo\Contracts\Orders\Order;
+use DuncanMcClean\Cargo\Payments\Gateways\Mollie;
+
+Mollie::paymentDescription(function (Order $order) {
+    return "Acme Store - {$order->orderNumber()}";
+});
+```
 
 ## Pay on delivery
 In some markets, you may wish to offer "Pay on delivery" instead of requiring payment upfront. To do this, simply add the built-in `pay_on_delivery` payment gateway to your gateways array:

--- a/src/Payments/Gateways/Mollie.php
+++ b/src/Payments/Gateways/Mollie.php
@@ -18,12 +18,15 @@ use Mollie\Api\MollieApiClient;
 use Mollie\Api\Types\PaymentStatus;
 use Statamic\Contracts\Auth\User;
 use Statamic\Sites\Site;
+use Closure;
 use Statamic\Statamic;
 use Statamic\Support\Arr;
 
 class Mollie extends PaymentGateway
 {
-    protected $mollie;
+    protected static ?Closure $paymentDescriptionResolver = null;
+
+    private $mollie;
 
     public function __construct()
     {
@@ -133,7 +136,9 @@ class Mollie extends PaymentGateway
         }
 
         $this->mollie->payments->update($payment->id, [
-            'description' => str_replace(':orderNumber', $order->orderNumber(), $this->config()->get('description', 'Order #:orderNumber')),
+            'description' => static::$paymentDescriptionResolver
+                ? call_user_func(static::$paymentDescriptionResolver, $order)
+                : __('Order #:orderNumber', ['orderNumber' => $order->orderNumber()]),
             'metadata' => array_merge((array) $payment->metadata, [
                 'order_id' => $order->id(),
                 'order_number' => $order->orderNumber(),
@@ -204,7 +209,12 @@ class Mollie extends PaymentGateway
         ];
     }
 
-    protected function formatAmount(Site $site, int $amount): array
+    public static function paymentDescription(Closure $callback): void
+    {
+        static::$paymentDescriptionResolver = $callback;
+    }
+
+    private function formatAmount(Site $site, int $amount): array
     {
         return [
             'currency' => Str::upper($site->attribute('currency')),

--- a/src/Payments/Gateways/Mollie.php
+++ b/src/Payments/Gateways/Mollie.php
@@ -2,6 +2,7 @@
 
 namespace DuncanMcClean\Cargo\Payments\Gateways;
 
+use Closure;
 use DuncanMcClean\Cargo\Cargo;
 use DuncanMcClean\Cargo\Contracts\Cart\Cart;
 use DuncanMcClean\Cargo\Contracts\Orders\Order;
@@ -18,7 +19,6 @@ use Mollie\Api\MollieApiClient;
 use Mollie\Api\Types\PaymentStatus;
 use Statamic\Contracts\Auth\User;
 use Statamic\Sites\Site;
-use Closure;
 use Statamic\Statamic;
 use Statamic\Support\Arr;
 

--- a/src/Payments/Gateways/Mollie.php
+++ b/src/Payments/Gateways/Mollie.php
@@ -23,7 +23,7 @@ use Statamic\Support\Arr;
 
 class Mollie extends PaymentGateway
 {
-    private $mollie;
+    protected $mollie;
 
     public function __construct()
     {
@@ -204,7 +204,7 @@ class Mollie extends PaymentGateway
         ];
     }
 
-    private function formatAmount(Site $site, int $amount): array
+    protected function formatAmount(Site $site, int $amount): array
     {
         return [
             'currency' => Str::upper($site->attribute('currency')),

--- a/src/Payments/Gateways/Mollie.php
+++ b/src/Payments/Gateways/Mollie.php
@@ -133,7 +133,7 @@ class Mollie extends PaymentGateway
         }
 
         $this->mollie->payments->update($payment->id, [
-            'description' => __('Order #:orderNumber', ['orderNumber' => $order->orderNumber()]),
+            'description' => str_replace(':orderNumber', $order->orderNumber(), $this->config()->get('description', 'Order #:orderNumber')),
             'metadata' => array_merge((array) $payment->metadata, [
                 'order_id' => $order->id(),
                 'order_number' => $order->orderNumber(),

--- a/src/Payments/Gateways/Stripe.php
+++ b/src/Payments/Gateways/Stripe.php
@@ -18,11 +18,14 @@ use Stripe\Event;
 use Stripe\Exception\SignatureVerificationException;
 use Stripe\PaymentIntent;
 use Stripe\Refund;
+use Closure;
 use Stripe\WebhookSignature;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class Stripe extends PaymentGateway
 {
+    protected static ?Closure $paymentDescriptionResolver = null;
+
     public function __construct()
     {
         \Stripe\Stripe::setApiKey($this->config()->get('secret'));
@@ -88,7 +91,9 @@ class Stripe extends PaymentGateway
     public function process(Order $order): void
     {
         PaymentIntent::update($order->get('stripe_payment_intent'), [
-            'description' => str_replace(':orderNumber', $order->orderNumber(), $this->config()->get('description', 'Order #:orderNumber')),
+            'description' => static::$paymentDescriptionResolver
+                ? call_user_func(static::$paymentDescriptionResolver, $order)
+                : __('Order #:orderNumber', ['orderNumber' => $order->orderNumber()]),
             'metadata' => [
                 'order_id' => $order->id(),
                 'order_number' => $order->orderNumber(),
@@ -201,5 +206,10 @@ class Stripe extends PaymentGateway
             __('Payment ID') => "<a href='https://dashboard.stripe.com/payments/{$order->get('stripe_payment_intent')}' target='_blank'>{$order->get('stripe_payment_intent')}</a>",
             __('Amount') => Money::format($order->grandTotal(), $order->site()),
         ];
+    }
+
+    public static function paymentDescription(Closure $callback): void
+    {
+        static::$paymentDescriptionResolver = $callback;
     }
 }

--- a/src/Payments/Gateways/Stripe.php
+++ b/src/Payments/Gateways/Stripe.php
@@ -2,6 +2,7 @@
 
 namespace DuncanMcClean\Cargo\Payments\Gateways;
 
+use Closure;
 use DuncanMcClean\Cargo\Cargo;
 use DuncanMcClean\Cargo\Contracts\Cart\Cart;
 use DuncanMcClean\Cargo\Contracts\Orders\Order;
@@ -18,7 +19,6 @@ use Stripe\Event;
 use Stripe\Exception\SignatureVerificationException;
 use Stripe\PaymentIntent;
 use Stripe\Refund;
-use Closure;
 use Stripe\WebhookSignature;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 

--- a/src/Payments/Gateways/Stripe.php
+++ b/src/Payments/Gateways/Stripe.php
@@ -88,7 +88,7 @@ class Stripe extends PaymentGateway
     public function process(Order $order): void
     {
         PaymentIntent::update($order->get('stripe_payment_intent'), [
-            'description' => __('Order #:orderNumber', ['orderNumber' => $order->orderNumber()]),
+            'description' => str_replace(':orderNumber', $order->orderNumber(), $this->config()->get('description', 'Order #:orderNumber')),
             'metadata' => [
                 'order_id' => $order->id(),
                 'order_number' => $order->orderNumber(),


### PR DESCRIPTION
## Summary
- Adds support for a `description` config option on both the Stripe and Mollie payment gateways, using `:orderNumber` as a placeholder
- Defaults to `Order #:orderNumber` for backwards compatibility
- Changes Mollie's `$mollie` property and `formatAmount()` from `private` to `protected` so subclasses can extend the gateway without duplicating the API client

## Example config
```php
'stripe' => [
    'description' => env('STRIPE_PAYMENT_DESCRIPTION', 'Order #:orderNumber'),
],
'mollie' => [
    'description' => env('MOLLIE_PAYMENT_DESCRIPTION', 'Order #:orderNumber'),
],
```