### PR TITLE
Prevent errors when viewing orders with deleted products

### DIFF
--- a/src/Orders/AugmentedOrder.php
+++ b/src/Orders/AugmentedOrder.php
@@ -61,7 +61,7 @@ class AugmentedOrder extends AugmentedCart
     public function downloads(): LineItems
     {
         return $this->data->lineItems()
-            ->filter(fn (LineItem $lineItem) => $lineItem->variant()?->has('downloads') ?? $lineItem->product()->has('downloads'))
+            ->filter(fn (LineItem $lineItem) => $lineItem->variant()?->has('downloads') ?? $lineItem->product()?->has('downloads'))
             ->map(fn (LineItem $lineItem) => [
                 'product' => $lineItem->product(),
                 'variant' => $lineItem->variant(),

--- a/src/Orders/LineItem.php
+++ b/src/Orders/LineItem.php
@@ -130,7 +130,7 @@ class LineItem
 
     public function hasDownloads(): bool
     {
-        return $this->variant()?->has('downloads') ?? $this->product()->has('downloads');
+        return $this->variant()?->has('downloads') ?? $this->product()?->has('downloads') ?? false;
     }
 
     public function defaultAugmentedArrayKeys()


### PR DESCRIPTION
This pull request fixes two errors which would occur when viewing an order containing deleted products.

We fixed a similar issue for carts in #154 where we removed line items w/ deleted products. However, we can't do that for orders as the line items need to stay in the same state as they were when the order was placed.

Obviously, when a product has been deleted, we can't show its title, so we show its ID instead.

Fixes #199
