### PR TITLE
Fix CartShippingController throwing ValidationException with a string

### DIFF
--- a/src/Http/Controllers/CartShippingController.php
+++ b/src/Http/Controllers/CartShippingController.php
@@ -16,12 +16,16 @@ class CartShippingController
 
         $cart = Cart::current();
 
-        if (! $cart->shippingAddress()) {
-            throw new ValidationException('cargo::validation.shipping_address_missing');
+        if (! $cart->hasShippingAddress()) {
+            throw ValidationException::withMessages([
+                'shipping_address' => __('cargo::validation.shipping_address_missing'),
+            ]);
         }
 
         if (! $this->hasPhysicalProducts($cart)) {
-            throw new ValidationException('cargo::validation.no_physical_products');
+            throw ValidationException::withMessages([
+                'line_items' => __('cargo::validation.no_physical_products'),
+            ]);
         }
 
         return ShippingMethod::all()

--- a/tests/Cart/CartShippingControllerTest.php
+++ b/tests/Cart/CartShippingControllerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\Fixtures\ShippingMethods\FakeShippingMethod;
 use Tests\TestCase;
 
 class CartShippingControllerTest extends TestCase
@@ -18,6 +19,26 @@ class CartShippingControllerTest extends TestCase
         parent::setUp();
 
         Cart::forgetCurrentCart();
+    }
+
+    #[Test]
+    public function it_returns_shipping_options()
+    {
+        FakeShippingMethod::register();
+
+        config()->set('statamic.cargo.shipping.methods', [
+            'fake_shipping_method' => [],
+        ]);
+
+        $cart = $this->makeCart();
+        $cart->merge(['shipping_address' => ['country' => 'US']])->save();
+
+        $this
+            ->getJson('/!/cargo/cart/shipping')
+            ->assertOk()
+            ->assertJsonStructure([
+                '*' => ['name', 'price'],
+            ]);
     }
 
     #[Test]

--- a/tests/Cart/CartShippingControllerTest.php
+++ b/tests/Cart/CartShippingControllerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Cart;
+
+use DuncanMcClean\Cargo\Facades\Cart;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class CartShippingControllerTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cart::forgetCurrentCart();
+    }
+
+    #[Test]
+    public function it_throws_a_not_found_exception_when_no_current_cart_is_set()
+    {
+        $this
+            ->getJson('/!/cargo/cart/shipping')
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function it_returns_a_validation_error_when_the_cart_has_no_shipping_address()
+    {
+        $this->makeCart();
+
+        $this
+            ->getJson('/!/cargo/cart/shipping')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'shipping_address' => 'Shipping address is missing from the cart.',
+            ]);
+    }
+
+    #[Test]
+    public function it_returns_a_validation_error_when_the_cart_has_no_physical_products()
+    {
+        $cart = $this->makeCart(productType: 'digital');
+        $cart->merge(['shipping_address' => ['country' => 'US']]);
+        $cart->save();
+
+        $this
+            ->getJson('/!/cargo/cart/shipping')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'line_items' => 'This cart does not contain any physical products.',
+            ]);
+    }
+
+    protected function makeCart(string $productType = 'physical')
+    {
+        Collection::make('products')->save();
+        Entry::make()
+            ->collection('products')
+            ->id('product-1')
+            ->data(['title' => 'Product 1', 'price' => 1000, 'type' => $productType])
+            ->save();
+
+        $cart = Cart::make()
+            ->customer(['name' => 'John Doe', 'email' => 'john.doe@example.com'])
+            ->lineItems([
+                [
+                    'product' => 'product-1',
+                    'quantity' => 1,
+                    'total' => 1000,
+                ],
+            ]);
+
+        $cart->save();
+
+        Cart::setCurrent($cart);
+
+        return $cart;
+    }
+}


### PR DESCRIPTION
## Summary
- Both checks in `CartShippingController` called `new ValidationException('cargo::validation.…')` with a translation key string. `ValidationException::__construct` expects a `Validator` instance, so as soon as Laravel called `summarize()` the response was a 500 with `Call to a member function errors() on string` instead of a 422.
- Switched both throws to `ValidationException::withMessages([...])` so the translated message is returned as a proper validation error.
- The address branch also had a dead-code condition: `! $cart->shippingAddress()` was always `false` because `shippingAddress()` returns an `Address` value object even when no address is stored. Switched to `! $cart->hasShippingAddress()` so the check actually fires.
- Added a feature test that covers both validation branches (and the existing not-found path), per your suggestion in #205.

## Notes
- Chose `shipping_address` and `line_items` as the validation error keys — happy to rename them if you'd prefer something else (e.g. namespacing both under `cart`).
- Tests pass locally on PHP 8.3 / PHPUnit 12.

Closes #205