### PR TITLE
Fix order search with separate first & last name fields

### DIFF
--- a/src/Fieldtypes/Orders.php
+++ b/src/Fieldtypes/Orders.php
@@ -86,8 +86,16 @@ class Orders extends Relationship
                 ->orWhere('order_number', 'LIKE', '%'.Str::remove('#', $search).'%')
                 ->orWhere(function ($query) use ($search) {
                     $users = User::query()
-                        ->where('name', 'LIKE', '%'.$search.'%')
-                        ->orWhere('email', 'LIKE', '%'.$search.'%')
+                        ->where('email', 'LIKE', '%'.$search.'%')
+                        ->when(User::blueprint()->hasField('first_name'), function ($query) use ($search) {
+                            foreach (explode(' ', $search) as $word) {
+                                $query
+                                    ->orWhere('first_name', 'LIKE', '%'.$word.'%')
+                                    ->orWhere('last_name', 'LIKE', '%'.$word.'%');
+                            }
+                        }, function ($query) use ($search) {
+                            $query->orWhere('name', 'LIKE', '%'.$search.'%');
+                        })
                         ->pluck('id')
                         ->all();
 

--- a/src/Http/Controllers/CP/Orders/OrderController.php
+++ b/src/Http/Controllers/CP/Orders/OrderController.php
@@ -80,8 +80,16 @@ class OrderController extends CpController
                 ->orWhere('order_number', 'LIKE', '%'.Str::remove('#', $search).'%')
                 ->orWhere(function ($query) use ($search) {
                     $users = User::query()
-                        ->where('name', 'LIKE', '%'.$search.'%')
-                        ->orWhere('email', 'LIKE', '%'.$search.'%')
+                        ->where('email', 'LIKE', '%'.$search.'%')
+                        ->when(User::blueprint()->hasField('first_name'), function ($query) use ($search) {
+                            foreach (explode(' ', $search) as $word) {
+                                $query
+                                    ->orWhere('first_name', 'LIKE', '%'.$word.'%')
+                                    ->orWhere('last_name', 'LIKE', '%'.$word.'%');
+                            }
+                        }, function ($query) use ($search) {
+                            $query->orWhere('name', 'LIKE', '%'.$search.'%');
+                        })
                         ->pluck('id')
                         ->all();
 


### PR DESCRIPTION
This PR fixes an issue when searching orders where it would error when the user's name is split into first and last name fields.

The error only occurs when storing users in the database as the Stache query builder ignores columns that don't exist.

Fixes #207
