### PR TITLE
Fix orphaned files when orders, carts, or discounts are resaved

### DIFF
--- a/src/Orders/Order.php
+++ b/src/Orders/Order.php
@@ -372,7 +372,7 @@ class Order implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableVal
                 $format .= 's';
             }
 
-            $prefix = $this->date->format($format).'.';
+            $prefix = $this->date->copy()->setTimezone(config('app.timezone'))->format($format).'.';
         }
 
         return vsprintf('%s/%s%s%s.yaml', [

--- a/src/Stache/Stores/CartsStore.php
+++ b/src/Stache/Stores/CartsStore.php
@@ -41,7 +41,8 @@ class CartsStore extends BasicStore
             ->discountTotal(Arr::pull($data, 'discount_total'))
             ->taxTotal(Arr::pull($data, 'tax_total'))
             ->shippingTotal(Arr::pull($data, 'shipping_total'))
-            ->data($data);
+            ->data($data)
+            ->initialPath($path);
     }
 
     protected function extractSiteFromPath($path)

--- a/src/Stache/Stores/DiscountsStore.php
+++ b/src/Stache/Stores/DiscountsStore.php
@@ -28,6 +28,7 @@ class DiscountsStore extends BasicStore
             ->handle((new GetSlugFromPath)($path))
             ->title(Arr::pull($data, 'title'))
             ->type(Arr::pull($data, 'type'))
-            ->data($data);
+            ->data($data)
+            ->initialPath($path);
     }
 }

--- a/src/Stache/Stores/OrdersStore.php
+++ b/src/Stache/Stores/OrdersStore.php
@@ -48,7 +48,8 @@ class OrdersStore extends BasicStore
             ->discountTotal(Arr::pull($data, 'discount_total'))
             ->taxTotal(Arr::pull($data, 'tax_total'))
             ->shippingTotal(Arr::pull($data, 'shipping_total'))
-            ->data($data);
+            ->data($data)
+            ->initialPath($path);
     }
 
     private function getDateFromPath($path)


### PR DESCRIPTION
This pull request fixes an issue where orders, carts, and discounts would leave orphaned YAML files on disk when reloaded and subsequently saved.

* Fixes issue where the original file wasn't being deleted when an item was resaved with a different path
   * This was happening because `OrdersStore`, `CartsStore`, and `DiscountsStore` weren't calling `->initialPath($path)` when loading items from files, so the `writeFile()` method didn't know which file to delete
   * I've fixed it by adding `->initialPath($path)` to the `makeItemFromFile()` method in all three stores

* Fixes issue where order filenames would shift by the timezone offset when reloaded and resaved
   * This was happening because `Order::buildPath()` formatted the date in UTC, but `OrdersStore::getDateFromPath()` parsed the filename as app timezone before converting to UTC
   * I've fixed it by formatting the date in app timezone when building the path, matching the parsing behavior

Fixes #209