### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
       github-actions:
         patterns:
           - "*"
+    # Supply chain attack mitigation: wait 7 days before updating
+    # to allow community detection of compromised releases
+    cooldown:
+      default-days: 7

--- a/.github/workflows/code-style-lint.yaml
+++ b/.github/workflows/code-style-lint.yaml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   lint-code-styling:
+    name: Lint code styling
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Check PHP code style issues
-        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # v2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
         with:
           testMode: true
           verboseMode: true

--- a/.github/workflows/code-style-lint.yaml
+++ b/.github/workflows/code-style-lint.yaml
@@ -3,13 +3,23 @@ name: Lint code style issues
 on:
   pull_request:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-code-styling:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check PHP code style issues
         uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # v2.6

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,10 +7,17 @@ on:
     paths:
       - 'docs/**'
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-docs:
     name: 'Update docs'
     runs-on: ubuntu-latest
+    permissions: {}
 
     steps:
       - name: Deploy

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,23 +5,26 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release:
     name: Prepare & Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: 8.4
           extensions: fileinfo, exif, gd, pdo, sqlite, pdo_sqlite, intl
 
       - name: Install composer dependencies
@@ -49,36 +52,27 @@ jobs:
         with:
           version: ${{ github.ref }}
 
+      - name: Determine prerelease status
+        id: prerelease
+        run: |
+          if [[ "${{ github.ref }}" == *"-alpha"* ]] || [[ "${{ github.ref }}" == *"-beta"* ]]; then
+            echo "flag=--prerelease" >> $GITHUB_OUTPUT
+          else
+            echo "flag=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create release
-        id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: ${{ steps.changelog.outputs.text }}
-          prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') }}
-
-      - name: Upload dist zip to release
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./resources/dist.tar.gz
-          asset_name: dist.tar.gz
-          asset_content_type: application/tar+gz
-
-      - name: Upload dist-checkout zip to release
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./resources/dist-checkout.tar.gz
-          asset_name: dist-checkout.tar.gz
-          asset_content_type: application/tar+gz
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+          CHANGELOG: ${{ steps.changelog.outputs.text }}
+        run: |
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --notes "$CHANGELOG" \
+            ${{ steps.prerelease.outputs.flag }} \
+            ./resources/dist.tar.gz \
+            ./resources/dist-checkout.tar.gz
 
       - name: Comment on related issues
         uses: duncanmcclean/post-release-comments@ee2d062e73bd6f0898f36ed892953ed88134cc19 # v1.0.6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,14 +7,18 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Prepare & Create Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: write # Create releases and upload assets
+      issues: write # Comment on related issues
+      pull-requests: write # Comment on related PRs
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -54,8 +58,10 @@ jobs:
 
       - name: Determine prerelease status
         id: prerelease
+        env:
+          REF: ${{ github.ref }}
         run: |
-          if [[ "${{ github.ref }}" == *"-alpha"* ]] || [[ "${{ github.ref }}" == *"-beta"* ]]; then
+          if [[ "$REF" == *"-alpha"* ]] || [[ "$REF" == *"-beta"* ]]; then
             echo "flag=--prerelease" >> $GITHUB_OUTPUT
           else
             echo "flag=" >> $GITHUB_OUTPUT
@@ -66,11 +72,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
           CHANGELOG: ${{ steps.changelog.outputs.text }}
+          PRERELEASE_FLAG: ${{ steps.prerelease.outputs.flag }}
         run: |
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
             --notes "$CHANGELOG" \
-            ${{ steps.prerelease.outputs.flag }} \
+            $PRERELEASE_FLAG \
             ./resources/dist.tar.gz \
             ./resources/dist-checkout.tar.gz
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,11 +7,19 @@ on:
       - '*.x'
   pull_request:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   php_tests:
     if: "!contains(github.event.head_commit.message, 'changelog')"
 
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -30,6 +38,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -94,8 +94,8 @@ jobs:
           LARAVEL_VERSION: ${{ matrix.laravel }}
           STABILITY: ${{ matrix.stability }}
         run: |
-          composer require "illuminate/contracts:$LARAVEL_VERSION" --no-interaction --no-update
-          composer update --$STABILITY --prefer-dist --no-interaction --no-suggest
+          composer require "illuminate/contracts:${LARAVEL_VERSION}" --no-interaction --no-update
+          composer update "--${STABILITY}" --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
         if: steps.should-run-tests.outputs.result == 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -90,9 +90,12 @@ jobs:
 
       - name: Install dependencies
         if: steps.should-run-tests.outputs.result == 'true'
+        env:
+          LARAVEL_VERSION: ${{ matrix.laravel }}
+          STABILITY: ${{ matrix.stability }}
         run: |
-          composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
+          composer require "illuminate/contracts:$LARAVEL_VERSION" --no-interaction --no-update
+          composer update --$STABILITY --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
         if: steps.should-run-tests.outputs.result == 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -90,12 +90,10 @@ jobs:
 
       - name: Install dependencies
         if: steps.should-run-tests.outputs.result == 'true'
-        env:
-          LARAVEL_VERSION: ${{ matrix.laravel }}
-          STABILITY: ${{ matrix.stability }}
+        # zizmor: ignore[template-injection] - matrix values are defined in this file, not attacker-controlled
         run: |
-          composer require "illuminate/contracts:${LARAVEL_VERSION}" --no-interaction --no-update
-          composer update "--${STABILITY}" --prefer-dist --no-interaction --no-suggest
+          composer require "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-suggest
 
       - name: Execute tests
         if: steps.should-run-tests.outputs.result == 'true'

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,37 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches:
+      - 1.x
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+  pull_request:
+    paths:
+      - '.github/**.yml'
+      - '.github/**.yaml'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+          annotations: true
+          persona: pedantic


### PR DESCRIPTION
This pull request hardens our GitHub Actions workflows against supply chain attacks and follows security best practices.

**Changes:**

* Adds a new `zizmor` workflow that runs static analysis on all workflow files to catch security issues
* Adds a 7-day Dependabot cooldown for GitHub Actions updates, allowing community detection of compromised releases before auto-updating
* Applies least-privilege permissions across all workflows:
  * Root-level `permissions: {}` (deny-all default)
  * Job-level scoped permissions (e.g., `contents: read`)
  * `persist-credentials: false` on all checkout steps to prevent token leakage
* Adds concurrency controls to prevent redundant workflow runs during rapid commits
* Replaces archived `actions/create-release` and `actions/upload-release-asset` with the `gh` CLI in the release workflow