### PR TITLE
Pre-built checkout: Various accessibility tweaks

### DIFF
--- a/resources/views/checkout/components/_banner.antlers.html
+++ b/resources/views/checkout/components/_banner.antlers.html
@@ -4,7 +4,7 @@
 #}}
 
 {{ get_error:checkout }}
-    <div class="relative w-full bg-red-700 z-60">
+    <div class="relative w-full bg-red-700 z-60" role="alert" aria-live="assertive">
         <div class="max-w-6xl mx-auto px-8 py-3">
             <p class="text-center text-white font-semibold">{{ message }}</p>
         </div>

--- a/resources/views/checkout/components/_button.antlers.html
+++ b/resources/views/checkout/components/_button.antlers.html
@@ -11,9 +11,11 @@
     type="{{ type ?? 'submit' }}"
     :disabled="{{ disabled || 'busy' }}"
     {{ if xOnClick }} @click="{{ xOnClick }}" {{ /if }}
-    class="w-full flex items-center justify-center rounded-md border border-transparent bg-secondary hover:bg-secondary/90 px-4 py-1.5 text-base font-medium text-white shadow-sm hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 cursor-pointer disabled:cursor-not-allowed"
+    :aria-busy="{{ disabled || 'busy' }}"
+    class="w-full flex items-center justify-center rounded-md border border-transparent bg-secondary hover:bg-secondary/90 px-4 py-1.5 text-base font-medium text-white shadow-sm hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-secondary focus:ring-offset-2 cursor-pointer disabled:cursor-not-allowed disabled:opacity-75"
 >
-    <svg x-show="{{ disabled || 'busy' }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-8 h-8 animate-spin text-white/75">
+    <span x-show="{{ disabled || 'busy' }}" class="sr-only">{{ 'Loading...' | trans }}</span>
+    <svg x-show="{{ disabled || 'busy' }}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-8 h-8 animate-spin text-white/75" aria-hidden="true">
         <style>@keyframes spinner_svv2{to{transform:rotate(360deg)}}</style>
         <path d="M10.14 1.16a11 11 0 0 0-9 8.92A1.59 1.59 0 0 0 2.46 12a1.52 1.52 0 0 0 1.65-1.3 8 8 0 0 1 6.66-6.61A1.42 1.42 0 0 0 12 2.69a1.57 1.57 0 0 0-1.86-1.53Z" style="transform-origin:center;animation:spinner_svv2 1.5s infinite linear" fill="currentColor"/>
     </svg>

--- a/resources/views/checkout/components/_cart_summary.antlers.html
+++ b/resources/views/checkout/components/_cart_summary.antlers.html
@@ -4,7 +4,7 @@
 #}}
 
 <template x-if="cart">
-    <div class="p-8 flex flex-col space-y-6 text-sm">
+    <div class="p-8 flex flex-col space-y-6 text-sm" aria-label="{{ 'Order summary' | trans }}" role="region" aria-live="polite">
         <ul class="flex flex-col space-y-6">
             {{ cart:line_items }}
                 <li class="flex items-center justify-between">
@@ -41,14 +41,18 @@
 
         <template x-if="!cart.discount_code && !cart.is_free">
             {{ cart:update x-data="ApplyDiscountCodeForm" @submit.prevent="applyDiscountCode" }}
+                <label for="discount_code" class="sr-only">{{ 'Discount code' | trans }}</label>
                 <div class="flex items-center">
                     <input
                         type="text"
+                        id="discount_code"
                         name="discount_code"
-                        placeholder="Discount code"
+                        placeholder="{{ 'Discount code' | trans }}"
                         x-model="discountCode"
                         class="block w-full rounded-md border-gray-300 shadow-sm focus:border-secondary focus:ring-secondary sm:text-sm"
                         autocomplete="off"
+                        :aria-invalid="error ? 'true' : 'false'"
+                        :aria-describedby="error ? 'discount-code-error' : null"
                     >
                     <button
                         type="submit"
@@ -60,7 +64,7 @@
                 </div>
 
                 <template x-if="error">
-                    <p class="text-red-600 text-sm mt-1" x-text="error"></p>
+                    <p id="discount-code-error" class="text-red-600 text-sm mt-1" x-text="error" role="alert" aria-live="assertive"></p>
                 </template>
             {{ /cart:update }}
         </template>
@@ -80,8 +84,8 @@
                             {{ cart:update class="flex items-center" x-data="RemoveDiscountCodeForm" @submit.prevent="removeDiscountCode" }}
                                 <input type="hidden" name="discount_code" value="">
 
-                                <button class="text-xs text-gray-500 hover:text-black" title="Remove discount code">
-                                    <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                                <button class="text-xs text-gray-500 hover:text-black focus:outline-none focus:ring-2 focus:ring-secondary focus:ring-offset-1 rounded" title="{{ 'Remove discount code' | trans }}" aria-label="{{ 'Remove discount code' | trans }}">
+                                    <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
                                         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
                                     </svg>
                                 </button>

--- a/resources/views/checkout/components/_combobox.antlers.html
+++ b/resources/views/checkout/components/_combobox.antlers.html
@@ -134,9 +134,11 @@
             @input="search = $event.target.value"
             {{ if autocomplete }}autocomplete="{{ autocomplete }}"{{ /if }}
             {{ if placeholder }}placeholder="{{ placeholder | trans }}"{{ /if }}
-            {{ if required }}required{{ /if }}
+            {{ if required }}required aria-required="true"{{ /if }}
             :class="{ 'cursor-pointer': !open }"
             class="block w-full rounded-md border-gray-300 shadow-sm focus:border-secondary focus:ring-secondary sm:text-sm pr-10"
+            :aria-invalid="errors && errors['{{ name }}'] ? 'true' : undefined"
+            :aria-describedby="errors && errors['{{ name }}'] ? '{{ field_id }}-error' : undefined"
         >
 
         <input type="hidden" name="{{ name }}" :value="{{ model }}">
@@ -194,7 +196,7 @@
     </div>
 
     <template x-if="errors && errors['{{ name }}']">
-        <ul class="mt-1">
+        <ul id="{{ field_id }}-error" class="mt-1" role="alert" aria-live="assertive">
             <template x-for="error in errors['{{ name }}']">
                 <li class="text-red-600 text-sm" x-text="error"></li>
             </template>

--- a/resources/views/checkout/components/_input.antlers.html
+++ b/resources/views/checkout/components/_input.antlers.html
@@ -24,14 +24,16 @@
             {{ if placeholder }}placeholder="{{ placeholder | trans }}"{{ /if }}
             {{ if value }}value="{{ value }}"{{ /if }}
             {{ if xBindValue }}:value="{{ xBindValue }}"{{ /if }}
-            {{ if required }}required{{ /if }}
+            {{ if required }}required aria-required="true"{{ /if }}
             {{ if disabled }}disabled readonly{{ /if }}
             class="block w-full rounded-md border-gray-300 shadow-sm focus:border-secondary focus:ring-secondary sm:text-sm disabled:bg-gray-100 disabled:text-gray-500 disabled:cursor-not-allowed"
+            :aria-invalid="errors.hasOwnProperty('{{ name }}') ? 'true' : undefined"
+            :aria-describedby="errors.hasOwnProperty('{{ name }}') ? '{{ name }}-error' : undefined"
         >
     </div>
 
     <template x-if="errors.hasOwnProperty('{{ name }}')">
-        <ul class="mt-1">
+        <ul id="{{ name }}-error" class="mt-1" role="alert" aria-live="assertive">
             <template x-for="error in errors['{{ name }}']">
                 <li class="text-red-600 text-sm" x-text="error"></li>
             </template>

--- a/resources/views/checkout/components/_select.antlers.html
+++ b/resources/views/checkout/components/_select.antlers.html
@@ -16,16 +16,18 @@
             id="{{ name }}"
             name="{{ name }}"
             {{ if autocomplete }}autocomplete="{{ autocomplete }}"{{ /if }}
-            {{ if required }}required{{ /if }}
+            {{ if required }}required aria-required="true"{{ /if }}
             {{ if x-model }}x-model="{{ x-model }}"{{ /if }}
             class="block w-full rounded-md border-gray-300 shadow-sm focus:border-secondary focus:ring-secondary sm:text-sm"
+            :aria-invalid="errors.hasOwnProperty('{{ name }}') ? 'true' : undefined"
+            :aria-describedby="errors.hasOwnProperty('{{ name }}') ? '{{ name }}-error' : undefined"
         >
             {{ slot }}
         </select>
     </div>
 
     <template x-if="errors.hasOwnProperty('{{ name }}')">
-        <ul class="mt-1">
+        <ul id="{{ name }}-error" class="mt-1" role="alert" aria-live="assertive">
             <template x-for="error in errors['{{ name }}']">
                 <li class="text-red-600 text-sm" x-text="error"></li>
             </template>

--- a/resources/views/checkout/components/_step.antlers.html
+++ b/resources/views/checkout/components/_step.antlers.html
@@ -7,16 +7,17 @@
 
 {{ key = {title | slugify} }}
 
-<div id="step-{{ key }}">
+<div id="step-{{ key }}" role="region" aria-label="{{ title | trans }}">
     <template x-if="currentStep !== '{{ key }}'">
         <div class="border-b border-gray-200 pb-4 flex items-center justify-between">
             <h3 class="w-full cursor-auto text-left text-lg font-semibold text-gray-500">{{ title | trans }}</h3>
 
             <button
                 x-show="completedSteps.includes('{{ key }}')"
-                class="text-sm text-secondary font-semibold"
+                class="text-sm text-secondary font-semibold focus:outline-none focus:ring-2 focus:ring-secondary focus:ring-offset-2 rounded px-2 py-1"
                 :disabled="busy"
                 @click="goToStep('{{ key }}')"
+                aria-label="{{ trans key='Edit :step' step='{title | trans}' }}"
             >
                 {{ 'Edit' | trans }}
             </button>

--- a/resources/views/checkout/layout.antlers.html
+++ b/resources/views/checkout/layout.antlers.html
@@ -21,6 +21,12 @@
     <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 </head>
 <body class="font-sans antialiased">
+    <a href="#checkout-form" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:bg-secondary focus:text-white focus:px-4 focus:py-2 focus:rounded-md focus:font-medium focus:shadow-lg">
+        {{ 'Skip to checkout form' | trans }}
+    </a>
+    <a href="#order-summary" class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-48 focus:z-[100] focus:bg-secondary focus:text-white focus:px-4 focus:py-2 focus:rounded-md focus:font-medium focus:shadow-lg">
+        {{ 'Skip to order summary' | trans }}
+    </a>
     <div class="relative md:min-h-screen">
         <div class="hidden md:block fixed top-0 left-0 w-1/2 bg-[#F8FAFC] h-screen"></div>
         <div class="hidden md:block fixed top-0 right-0 w-1/2 bg-white h-screen"></div>
@@ -28,15 +34,15 @@
         {{ partial:checkout/components/banner }}
 
         <div id="Checkout" class="relative flex flex-col-reverse md:flex-row md:min-h-screen max-w-6xl mx-auto">
-            <main class="md:w-3/5 bg-[#F8FAFC] min-h-screen">
+            <main id="checkout-form" class="md:w-3/5 bg-[#F8FAFC] min-h-screen" role="main" aria-label="{{ 'Checkout form' | trans }}">
                 <div class="flex flex-col">
                     {{ partial:checkout/header }}
 
                     <div x-data="{ show: false }" class="md:hidden bg-white border-y border-gray-200">
                         <div class="flex items-center justify-between px-8 py-4">
-                            <button class="text-secondary font-medium text-sm flex items-center w-full" @click="show = !show">
-                                Order summary
-                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 ml-1" :class="{ 'rotate-180': show }">
+                            <button class="text-secondary font-medium text-sm flex items-center w-full focus:outline-none focus:ring-2 focus:ring-secondary focus:ring-offset-2 rounded" @click="show = !show" :aria-expanded="show" aria-controls="mobile-order-summary">
+                                {{ 'Order summary' | trans }}
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-4 ml-1" :class="{ 'rotate-180': show }" aria-hidden="true">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
                                 </svg>
                             </button>
@@ -48,7 +54,7 @@
                             {{ /yield:summary_total }}
                         </div>
 
-                        <div x-cloak x-show="show">
+                        <div id="mobile-order-summary" x-cloak x-show="show">
                             {{ yield:sidebar }}
                         </div>
                     </div>
@@ -59,7 +65,7 @@
                 </div>
             </main>
 
-            <aside class="hidden md:block md:w-2/5 min-h-full border-l border-gray-200 bg-white">
+            <aside id="order-summary" class="hidden md:block md:w-2/5 min-h-full border-l border-gray-200 bg-white" aria-label="{{ 'Order summary' | trans }}">
                 <div class="bg-white w-full h-full">
                     {{ yield:sidebar }}
                 </div>

--- a/resources/views/checkout/steps/_shipping.antlers.html
+++ b/resources/views/checkout/steps/_shipping.antlers.html
@@ -11,37 +11,41 @@
         <input type="hidden" name="shipping_method" x-model="selectedShippingMethod">
 
         <template x-if="isFetchingShippingOptions">
-            <div class="py-4 flex flex-col items-center justify-center -mb-6">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-8 h-8 animate-spin text-black mb-4">
+            <div class="py-4 flex flex-col items-center justify-center -mb-6" role="status" aria-live="polite">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-8 h-8 animate-spin text-black mb-4" aria-hidden="true">
                     <style>@keyframes spinner_svv2{to{transform:rotate(360deg)}}</style>
                     <path d="M10.14 1.16a11 11 0 0 0-9 8.92A1.59 1.59 0 0 0 2.46 12a1.52 1.52 0 0 0 1.65-1.3 8 8 0 0 1 6.66-6.61A1.42 1.42 0 0 0 12 2.69a1.57 1.57 0 0 0-1.86-1.53Z" style="transform-origin:center;animation:spinner_svv2 1.5s infinite linear" fill="currentColor"/>
                 </svg>
-                <span class="text-gray-500 font-medium">{{ 'Loading...' | trans }}</span>
+                <span class="text-gray-500 font-medium">{{ 'Loading shipping options...' | trans }}</span>
             </div>
         </template>
 
-        <p x-show="!isFetchingShippingOptions && shippingOptions.length === 0">{{ "Sorry, we're not able to ship to your address." | trans }}</p>
+        <p x-show="!isFetchingShippingOptions && shippingOptions.length === 0" role="alert">{{ "Sorry, we're not able to ship to your address." | trans }}</p>
 
         <template x-if="!isFetchingShippingOptions && shippingOptions.length > 0">
-            <ul class="flex flex-col space-y-2">
+            <ul class="flex flex-col space-y-2" role="radiogroup" aria-label="{{ 'Shipping options' | trans }}" aria-live="polite">
                 <template x-for="shippingOption in shippingOptions">
-                    <li x-data class="bg-white border border-gray-300 rounded-md text-gray-700 text-sm p-4 flex items-center justify-between cursor-pointer" @click="$refs.shippingOption.click()">
+                    <li x-data class="bg-white border border-gray-300 rounded-md text-gray-700 text-sm p-4 flex items-center justify-between cursor-pointer focus-within:ring-2 focus-within:ring-secondary focus-within:ring-offset-1" :class="{ 'border-secondary': selectedShippingOption === shippingOption.handle }" @click="$refs.shippingOption.click()">
                         <div class="flex items-center space-x-2 flex-1">
                             <input
                                 x-ref="shippingOption"
                                 type="radio"
                                 name="shipping_option"
-                                class="checked:bg-secondary focus:bg-secondary checked:border-secondary focus:border-secondary accent-secondary"
+                                class="checked:bg-secondary focus:bg-secondary checked:border-secondary focus:border-secondary accent-secondary focus:ring-2 focus:ring-secondary focus:ring-offset-1"
                                 :id="shippingOption.handle"
                                 :value="shippingOption.handle"
                                 :checked="selectedShippingOption === shippingOption.handle"
+                                :aria-checked="selectedShippingOption === shippingOption.handle"
                                 @input="selectShippingOption(shippingOption)"
                                 required
                             >
-                            <label class="block text-gray-700 font-semibold flex-1 cursor-pointer" :for="shippingOption.handle" x-text="shippingOption.name"></label>
+                            <label class="block text-gray-700 font-semibold flex-1 cursor-pointer" :for="shippingOption.handle">
+                                <span x-text="shippingOption.name"></span>
+                                <span class="sr-only" x-text="` - ${shippingOption.price}`"></span>
+                            </label>
                         </div>
 
-                        <span x-text="shippingOption.price"></span>
+                        <span x-text="shippingOption.price" aria-hidden="true"></span>
                     </li>
                 </template>
             </ul>


### PR DESCRIPTION
This pull request improves accessibility across the pre-built checkout templates.

**Changes include:**

* Adds `aria-live` regions for dynamic content — the order summary, shipping options list, and error messages are now announced to screen readers when they update
* Adds `aria-describedby` to connect error messages with their related form inputs, along with `aria-invalid` states
* Adds `aria-required="true"` to all required form fields
* Adds skip links for keyboard navigation — users can now skip directly to the checkout form or order summary
* Improves focus visibility on interactive elements — Edit buttons, shipping options, discount code removal button, and mobile order summary toggle now have visible focus rings
* Adds `aria-hidden="true"` to decorative SVG icons
* Adds `aria-busy` state to submit buttons during form submission
* Adds screen-reader-only text for loading spinners
* Adds proper `role` attributes — `radiogroup` for shipping options, `region` for checkout steps, `alert` for error banners
* Adds `aria-expanded` and `aria-controls` to the mobile order summary toggle
* Adds `aria-label` to the remove discount code button