### PR TITLE
Relationship fieldtype adjustments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "mollie/mollie-api-php": "^3.0",
         "moneyphp/money": "^4.5",
         "pixelfear/composer-dist-plugin": "^0.1.0",
-        "statamic/cms": "^6.10",
+        "statamic/cms": "^6.20",
         "stillat/proteus": "^4.2.1",
         "stripe/stripe-php": "^16.4",
         "ext-zip": "*"

--- a/resources/js/components/fieldtypes/CustomersFieldtype.vue
+++ b/resources/js/components/fieldtypes/CustomersFieldtype.vue
@@ -74,9 +74,8 @@ function convertToUser() {
                 class="shadow-ui-sm related-item relative z-2 mb-1.5 flex h-full w-full items-center gap-2 rounded-lg border border-gray-200 bg-white px-1.5 py-1.5 text-base last:mb-0 dark:border-x-0 dark:border-t-0 dark:border-white/15 dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black"
             >
                 <div class="flex flex-1 items-center p-1">
-                    <Heading v-if="value.invalid" v-tooltip="__('An item with this ID could not be found')">
+                    <Heading v-if="value.invalid" v-tooltip="__('messages.relationship_item_unavailable')" class="text-gray-500 dark:text-gray-400">
                         {{ value.id }}
-                        <Badge pill color="red" :text="__('Invalid')" />
                     </Heading>
 
                     <div v-else>

--- a/resources/js/components/fieldtypes/OrderReceipt/LineItemRow.vue
+++ b/resources/js/components/fieldtypes/OrderReceipt/LineItemRow.vue
@@ -36,8 +36,9 @@ function itemUpdated(responseData) {
         <TableCell>
             <div
                 v-if="lineItem.product.invalid"
-                v-tooltip.top="__('A product with this ID could not be found')"
+                v-tooltip.top="__('messages.relationship_item_unavailable')"
                 v-text="lineItem.product.title"
+                class="text-gray-500 dark:text-gray-400"
             />
 
             <a v-else @click.prevent="edit" :href="lineItem.product.edit_url">

--- a/resources/js/components/orders/RelatedOrder.vue
+++ b/resources/js/components/orders/RelatedOrder.vue
@@ -57,9 +57,9 @@ function itemUpdated(responseData) {
 		<div class="flex flex-1 items-center justify-between p-1">
 			<div
 				v-if="item.invalid"
-				v-tooltip.top="__('ID not found')"
+				v-tooltip.top="__('messages.relationship_item_unavailable')"
 				v-text="__(item.title)"
-				class="line-clamp-1 text-sm text-gray-600 dark:text-gray-300"
+				class="line-clamp-1 text-sm text-gray-500 dark:text-gray-400"
 			/>
 
 			<div v-else>


### PR DESCRIPTION
This pull request updates invalid relationship item handling to be consistent with Statamic CMS core.

Statamic CMS recently changed how invalid/unavailable relationship items are displayed (statamic/cms#14718 and statamic/cms#14719). Previously, items used red/error styling with messages like "ID not found". Now they use muted gray styling with a generic "Unavailable" message via the `messages.relationship_item_unavailable` translation key.

This PR applies the same approach to Cargo's custom relationship-style components:

- `RelatedOrder.vue` - Updated tooltip and text color
- `CustomersFieldtype.vue` - Updated tooltip, removed red badge, added muted styling
- `LineItemRow.vue` - Updated tooltip and added muted styling

This PR also bumps the minimum `statamic/cms` requirement to `^6.20` to ensure the translation key is available.

---

Related: statamic/cms#14718
Related: statamic/cms#14719