### PR TITLE
Fix order number type inconsistency when loading from YAML

### DIFF
--- a/src/Stache/Stores/OrdersStore.php
+++ b/src/Stache/Stores/OrdersStore.php
@@ -37,7 +37,7 @@ class OrdersStore extends BasicStore
         return Order::make()
             ->site($site)
             ->id(Arr::pull($data, 'id'))
-            ->orderNumber((new GetSlugFromPath)($path))
+            ->orderNumber((int) (new GetSlugFromPath)($path))
             ->date($this->getDateFromPath($path))
             ->cart(Arr::pull($data, 'cart'))
             ->status(Arr::pull($data, 'status'))


### PR DESCRIPTION
This pull request fixes an issue where `orderNumber` was returned as an integer for newly created orders, but as a string when orders were reloaded from YAML files.

This was happening because `GetSlugFromPath` extracts the order number from the filename as a string, while `generateOrderNumber()` returns an integer.

This PR fixes it by casting to int when loading the order number from the file path in `OrdersStore`.

Fixes #221