### PR TITLE
Fix cart session bleed on login/logout

### DIFF
--- a/src/Listeners/AssignUserToCart.php
+++ b/src/Listeners/AssignUserToCart.php
@@ -2,6 +2,7 @@
 
 namespace DuncanMcClean\Cargo\Listeners;
 
+use DuncanMcClean\Cargo\Customers\GuestCustomer;
 use DuncanMcClean\Cargo\Facades\Cart;
 use DuncanMcClean\Cargo\Facades\Order;
 use DuncanMcClean\Cargo\Orders\LineItem;
@@ -23,7 +24,17 @@ class AssignUserToCart
 
         if (! $recentCart) {
             if (Cart::hasCurrentCart()) {
-                Cart::current()->customer(User::fromUser($event->user))->save();
+                $currentCart = Cart::current();
+                $existingCustomer = $currentCart->customer();
+
+                // Don't reassign a cart that already belongs to a different registered user.
+                if ($existingCustomer && ! $existingCustomer instanceof GuestCustomer && $existingCustomer->id() !== $user->id()) {
+                    Cart::forgetCurrentCart();
+
+                    return;
+                }
+
+                $currentCart->customer(User::fromUser($event->user))->save();
             }
 
             return;

--- a/src/Listeners/ForgetCartOnLogout.php
+++ b/src/Listeners/ForgetCartOnLogout.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Listeners;
+
+use DuncanMcClean\Cargo\Facades\Cart;
+use Illuminate\Auth\Events\Logout;
+
+class ForgetCartOnLogout
+{
+    public function handle(Logout $event): void
+    {
+        Cart::forgetCurrentCart();
+    }
+}

--- a/tests/Customers/AssignUserToCartTest.php
+++ b/tests/Customers/AssignUserToCartTest.php
@@ -129,6 +129,24 @@ class AssignUserToCartTest extends TestCase
         $this->assertEquals($user->id(), $currentCart->fresh()->customer()->id());
     }
 
+    #[Test]
+    public function cart_belonging_to_another_user_is_not_reassigned()
+    {
+        $userA = User::make()->save();
+        $userB = User::make()->save();
+
+        $cartBelongingToUserA = tap(Cart::make()->customer($userA))->save();
+        Cart::setCurrent($cartBelongingToUserA);
+
+        Auth::login($userB);
+
+        // User A's cart should not have been reassigned to User B.
+        $this->assertEquals($userA->id(), $cartBelongingToUserA->fresh()->customer()->id());
+
+        // User B should not have a current cart.
+        $this->assertFalse(Cart::hasCurrentCart());
+    }
+
     protected function makeCart()
     {
         $cart = tap(Cart::make())->save();

--- a/tests/Customers/ForgetCartOnLogoutTest.php
+++ b/tests/Customers/ForgetCartOnLogoutTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Customers;
+
+use DuncanMcClean\Cargo\Facades\Cart;
+use Illuminate\Support\Facades\Auth;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ForgetCartOnLogoutTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cart::forgetCurrentCart();
+    }
+
+    #[Test]
+    public function current_cart_is_forgotten_on_logout()
+    {
+        $user = User::make()->save();
+        $cart = tap(Cart::make()->customer($user))->save();
+
+        Cart::setCurrent($cart);
+
+        $this->assertTrue(Cart::hasCurrentCart());
+
+        Auth::login($user);
+        Auth::logout();
+
+        $this->assertFalse(Cart::hasCurrentCart());
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where the `AssignUserToCart` listener would reassign a cart from a cookie to a newly logged-in user without checking if that cart already belonged to a different registered customer.

This was happening because the listener only checked if a current cart existed, not whether it was owned by someone else. In shared browser scenarios (shared computers, or multi-site setups with shared cookie domains), this could cause cart session bleed where User B could access User A's cart.

This PR fixes it by:

* Checking if the current cart already belongs to a different registered user before reassigning it. If it does, the cart cookie is cleared instead.
* Adding a new `ForgetCartOnLogout` listener that clears the cart cookie when a user logs out. This prevents the scenario where User A logs out, User B logs in on the same browser, and inherits User A's cart. The user will get their cart back on next login via the existing "recent cart" lookup.

Guest carts (with no customer or a guest customer) are still assigned to the user on login, preserving the expected behavior for new registrations.

Fixes #223