### PR TITLE
Fix passing `0` to `format_money` modifier

### DIFF
--- a/src/Modifiers/FormatMoney.php
+++ b/src/Modifiers/FormatMoney.php
@@ -10,7 +10,7 @@ class FormatMoney extends Modifier
 {
     public function index($value, $params, $context)
     {
-        if (! $value  && $value !== 0) {
+        if (! $value && $value !== 0) {
             return $value;
         }
 

--- a/src/Modifiers/FormatMoney.php
+++ b/src/Modifiers/FormatMoney.php
@@ -10,7 +10,7 @@ class FormatMoney extends Modifier
 {
     public function index($value, $params, $context)
     {
-        if (! $value) {
+        if (! $value  && $value !== 0) {
             return $value;
         }
 

--- a/src/Modifiers/FormatMoney.php
+++ b/src/Modifiers/FormatMoney.php
@@ -10,7 +10,7 @@ class FormatMoney extends Modifier
 {
     public function index($value, $params, $context)
     {
-        if (is_nullable($value)) {
+        if (is_null($value)) {
             return;
         }
 

--- a/src/Modifiers/FormatMoney.php
+++ b/src/Modifiers/FormatMoney.php
@@ -10,8 +10,8 @@ class FormatMoney extends Modifier
 {
     public function index($value, $params, $context)
     {
-        if (! $value && $value !== 0) {
-            return $value;
+        if (is_nullable($value)) {
+            return;
         }
 
         if (! is_numeric($value)) {


### PR DESCRIPTION
`formatMoney` modifier update to accept and format zero `0` money too. Since right now `0` is formatted as `0` and not as eg. `0,00 €`