### PR TITLE
Fix overriding repositories when storing data in the database

### DIFF
--- a/src/Cart/Eloquent/CartQueryBuilder.php
+++ b/src/Cart/Eloquent/CartQueryBuilder.php
@@ -3,6 +3,7 @@
 namespace DuncanMcClean\Cargo\Cart\Eloquent;
 
 use Closure;
+use DuncanMcClean\Cargo\Contracts\Cart\Cart;
 use DuncanMcClean\Cargo\Contracts\Cart\QueryBuilder;
 use DuncanMcClean\Cargo\Query\Eloquent\QueriesCustomers;
 use Illuminate\Support\Collection;
@@ -53,7 +54,7 @@ class CartQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
     protected function transform($items, $columns = ['*'])
     {
         return Collection::make($items)->map(function ($model) {
-            return Cart::fromModel($model);
+            return app(Cart::class)::fromModel($model);
         });
     }
 

--- a/src/Discounts/Eloquent/DiscountQueryBuilder.php
+++ b/src/Discounts/Eloquent/DiscountQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace DuncanMcClean\Cargo\Discounts\Eloquent;
 
+use DuncanMcClean\Cargo\Contracts\Discounts\Discount;
 use DuncanMcClean\Cargo\Contracts\Discounts\QueryBuilder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -37,7 +38,7 @@ class DiscountQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
     protected function transform($items, $columns = ['*'])
     {
         return Collection::make($items)->map(function ($model) {
-            return Discount::fromModel($model);
+            return app(Discount::class)::fromModel($model);
         });
     }
 

--- a/src/Orders/Eloquent/OrderQueryBuilder.php
+++ b/src/Orders/Eloquent/OrderQueryBuilder.php
@@ -3,6 +3,7 @@
 namespace DuncanMcClean\Cargo\Orders\Eloquent;
 
 use Closure;
+use DuncanMcClean\Cargo\Contracts\Orders\Order;
 use DuncanMcClean\Cargo\Contracts\Orders\QueryBuilder;
 use DuncanMcClean\Cargo\Query\Eloquent\QueriesCustomers;
 use Illuminate\Support\Collection;
@@ -53,7 +54,7 @@ class OrderQueryBuilder extends EloquentQueryBuilder implements QueryBuilder
     protected function transform($items, $columns = ['*'])
     {
         return Collection::make($items)->map(function ($model) {
-            return Order::fromModel($model);
+            return app(Order::class)::fromModel($model);
         });
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -153,14 +153,18 @@ class ServiceProvider extends AddonServiceProvider
 
     protected function bootRepositories(): self
     {
-        collect([
+        $repositories = [
             \DuncanMcClean\Cargo\Contracts\Cart\CartRepository::class => \DuncanMcClean\Cargo\Stache\Repositories\CartRepository::class,
             \DuncanMcClean\Cargo\Contracts\Discounts\DiscountRepository::class => \DuncanMcClean\Cargo\Stache\Repositories\DiscountRepository::class,
             \DuncanMcClean\Cargo\Contracts\Orders\OrderRepository::class => \DuncanMcClean\Cargo\Stache\Repositories\OrderRepository::class,
             \DuncanMcClean\Cargo\Contracts\Products\ProductRepository::class => \DuncanMcClean\Cargo\Products\ProductRepository::class,
             \DuncanMcClean\Cargo\Contracts\Taxes\TaxClassRepository::class => \DuncanMcClean\Cargo\Taxes\File\TaxClassRepository::class,
             \DuncanMcClean\Cargo\Contracts\Taxes\TaxZoneRepository::class => \DuncanMcClean\Cargo\Taxes\File\TaxZoneRepository::class,
-        ])->each(function ($concrete, $abstract) {
+        ];
+
+        $overridden = collect($repositories)->keys()->filter(fn ($abstract) => $this->app->bound($abstract));
+
+        collect($repositories)->each(function ($concrete, $abstract) {
             if (! $this->app->bound($abstract)) {
                 Statamic::repository($abstract, $concrete);
             }
@@ -175,10 +179,12 @@ class ServiceProvider extends AddonServiceProvider
                 return config('statamic.cargo.carts.line_items_model', \DuncanMcClean\Cargo\Cart\Eloquent\LineItemModel::class);
             });
 
-            Statamic::repository(
-                \DuncanMcClean\Cargo\Contracts\Cart\CartRepository::class,
-                \DuncanMcClean\Cargo\Cart\Eloquent\CartRepository::class
-            );
+            if (! $overridden->contains(Contracts\Cart\CartRepository::class)) {
+                Statamic::repository(
+                    \DuncanMcClean\Cargo\Contracts\Cart\CartRepository::class,
+                    \DuncanMcClean\Cargo\Cart\Eloquent\CartRepository::class
+                );
+            }
         }
 
         if (config('statamic.cargo.discounts.driver') === 'eloquent') {
@@ -186,10 +192,12 @@ class ServiceProvider extends AddonServiceProvider
                 return config('statamic.cargo.discounts.model', \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountModel::class);
             });
 
-            Statamic::repository(
-                \DuncanMcClean\Cargo\Contracts\Discounts\DiscountRepository::class,
-                \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountRepository::class
-            );
+            if (! $overridden->contains(Contracts\Discounts\DiscountRepository::class)) {
+                Statamic::repository(
+                    \DuncanMcClean\Cargo\Contracts\Discounts\DiscountRepository::class,
+                    \DuncanMcClean\Cargo\Discounts\Eloquent\DiscountRepository::class
+                );
+            }
         }
 
         if (config('statamic.cargo.orders.driver') === 'eloquent') {
@@ -201,20 +209,28 @@ class ServiceProvider extends AddonServiceProvider
                 return config('statamic.cargo.orders.line_items_model', \DuncanMcClean\Cargo\Orders\Eloquent\LineItemModel::class);
             });
 
-            Statamic::repository(
-                \DuncanMcClean\Cargo\Contracts\Orders\OrderRepository::class,
-                \DuncanMcClean\Cargo\Orders\Eloquent\OrderRepository::class
-            );
+            if (! $overridden->contains(Contracts\Orders\OrderRepository::class)) {
+                Statamic::repository(
+                    \DuncanMcClean\Cargo\Contracts\Orders\OrderRepository::class,
+                    \DuncanMcClean\Cargo\Orders\Eloquent\OrderRepository::class
+                );
+            }
         }
 
-        if (config('cargo.taxes.tax_classes.driver') === 'eloquent') {
+        if (
+            config('statamic.cargo.taxes.tax_classes.driver') === 'eloquent'
+            && ! $overridden->contains(Contracts\Taxes\TaxClassRepository::class)
+        ) {
             Statamic::repository(
                 \DuncanMcClean\Cargo\Contracts\Taxes\TaxClassRepository::class,
                 \DuncanMcClean\Cargo\Taxes\Eloquent\TaxClassRepository::class
             );
         }
 
-        if (config('cargo.taxes.tax_zones.driver') === 'eloquent') {
+        if (
+            config('statamic.cargo.taxes.tax_zones.driver') === 'eloquent'
+            && ! $overridden->contains(Contracts\Taxes\TaxZoneRepository::class)
+        ) {
             Statamic::repository(
                 \DuncanMcClean\Cargo\Contracts\Taxes\TaxZoneRepository::class,
                 \DuncanMcClean\Cargo\Taxes\Eloquent\TaxZoneRepository::class


### PR DESCRIPTION
This pull request fixes a few related issues around overriding repositories and custom models when storing data in the database.

Previously, a custom repository bound by the developer would get overridden by Cargo when using the Eloquent drivers. The default file/Stache repositories already guarded against this, but the Eloquent ones registered unconditionally and clobbered anything the developer had bound. This PR fixes it by capturing which repositories the developer has bound before registering any of Cargo's own, then skipping the Eloquent registration for those.

It also fixes an issue where queried carts, orders and discounts always used Cargo's own class, ignoring a custom class bound via the repository's `bindings()`. This was happening because the Eloquent query builders hardcoded the class in `transform()` (eg. `Cart::fromModel($model)`), so only newly made models respected the binding, not loaded ones. This PR resolves the class from the container instead (eg. `app(Cart::class)::fromModel($model)`).

Finally, it fixes the tax repositories never switching to the Eloquent driver after migrating to the database, which was caused by `bootRepositories()` checking the wrong config key (`cargo.taxes.*` instead of `statamic.cargo.taxes.*`).

Fixes #231
Fixes #232