### PR TITLE
Clear stale discount_breakdown in ResetTotals

### DIFF
--- a/src/Cart/Calculator/ResetTotals.php
+++ b/src/Cart/Calculator/ResetTotals.php
@@ -18,6 +18,7 @@ class ResetTotals
 
         $cart->remove('shipping_tax_total');
         $cart->remove('shipping_tax_breakdown');
+        $cart->remove('discount_breakdown');
 
         $cart->lineItems()->transform(function (LineItem $lineItem) {
             $lineItem->unitPrice(0);

--- a/tests/Cart/Calculator/ResetTotalsTest.php
+++ b/tests/Cart/Calculator/ResetTotalsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Cart\Calculator;
+
+use DuncanMcClean\Cargo\Cart\Calculator\ResetTotals;
+use DuncanMcClean\Cargo\Facades\Cart;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ResetTotalsTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_clears_a_stale_discount_breakdown()
+    {
+        // A discount_breakdown left over from a previous calculation (for example a
+        // bulk-quantity discount that applied before the quantity dropped back below
+        // the tier) must not survive a recalculation, otherwise the cart keeps
+        // showing a phantom discount line even though discountTotal is reset to zero.
+        $cart = Cart::make()->set('discount_breakdown', [
+            ['discount' => 'bulk', 'description' => 'Bulk Quantity Discount', 'amount' => 500],
+        ]);
+
+        $cart = app(ResetTotals::class)->handle($cart, fn ($cart) => $cart);
+
+        $this->assertFalse($cart->has('discount_breakdown'));
+        $this->assertNull($cart->get('discount_breakdown'));
+    }
+}

--- a/tests/Cart/Calculator/ResetTotalsTest.php
+++ b/tests/Cart/Calculator/ResetTotalsTest.php
@@ -5,6 +5,8 @@ namespace Tests\Cart\Calculator;
 use DuncanMcClean\Cargo\Cart\Calculator\ResetTotals;
 use DuncanMcClean\Cargo\Facades\Cart;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -12,13 +14,60 @@ class ResetTotalsTest extends TestCase
 {
     use PreventsSavingStacheItemsToDisk;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Collection::make('products')->save();
+        Entry::make()->id('product-id')->collection('products')->data(['price' => 500])->save();
+    }
+
+    #[Test]
+    public function it_resets_cart_totals_to_zero()
+    {
+        $cart = Cart::make()
+            ->grandTotal(1500)
+            ->subTotal(1000)
+            ->taxTotal(200)
+            ->shippingTotal(300)
+            ->discountTotal(500);
+
+        $cart = app(ResetTotals::class)->handle($cart, fn ($cart) => $cart);
+
+        $this->assertEquals(0, $cart->grandTotal());
+        $this->assertEquals(0, $cart->subTotal());
+        $this->assertEquals(0, $cart->taxTotal());
+        $this->assertEquals(0, $cart->shippingTotal());
+        $this->assertEquals(0, $cart->discountTotal());
+    }
+
+    #[Test]
+    public function it_clears_a_stale_shipping_tax_total()
+    {
+        $cart = Cart::make()->set('shipping_tax_total', 60);
+
+        $cart = app(ResetTotals::class)->handle($cart, fn ($cart) => $cart);
+
+        $this->assertFalse($cart->has('shipping_tax_total'));
+        $this->assertNull($cart->get('shipping_tax_total'));
+    }
+
+    #[Test]
+    public function it_clears_a_stale_shipping_tax_breakdown()
+    {
+        $cart = Cart::make()->set('shipping_tax_breakdown', [
+            ['rate' => 20, 'description' => 'VAT', 'zone' => 'uk', 'amount' => 60],
+        ]);
+
+        $cart = app(ResetTotals::class)->handle($cart, fn ($cart) => $cart);
+
+        $this->assertFalse($cart->has('shipping_tax_breakdown'));
+        $this->assertNull($cart->get('shipping_tax_breakdown'));
+    }
+
     #[Test]
     public function it_clears_a_stale_discount_breakdown()
     {
-        // A discount_breakdown left over from a previous calculation (for example a
-        // bulk-quantity discount that applied before the quantity dropped back below
-        // the tier) must not survive a recalculation, otherwise the cart keeps
-        // showing a phantom discount line even though discountTotal is reset to zero.
         $cart = Cart::make()->set('discount_breakdown', [
             ['discount' => 'bulk', 'description' => 'Bulk Quantity Discount', 'amount' => 500],
         ]);
@@ -27,5 +76,53 @@ class ResetTotalsTest extends TestCase
 
         $this->assertFalse($cart->has('discount_breakdown'));
         $this->assertNull($cart->get('discount_breakdown'));
+    }
+
+    #[Test]
+    public function it_resets_line_item_totals_to_zero()
+    {
+        $cart = Cart::make()->lineItems([
+            [
+                'product' => 'product-id',
+                'quantity' => 2,
+                'unit_price' => 500,
+                'sub_total' => 1000,
+                'tax_total' => 200,
+                'discount_total' => 100,
+                'total' => 1100,
+            ],
+        ]);
+
+        $cart = app(ResetTotals::class)->handle($cart, fn ($cart) => $cart);
+
+        $lineItem = $cart->lineItems()->first();
+
+        $this->assertEquals(0, $lineItem->unitPrice());
+        $this->assertEquals(0, $lineItem->subTotal());
+        $this->assertEquals(0, $lineItem->taxTotal());
+        $this->assertEquals(0, $lineItem->discountTotal());
+        $this->assertEquals(0, $lineItem->total());
+    }
+
+    #[Test]
+    public function it_clears_a_stale_tax_breakdown_from_line_items()
+    {
+        $cart = Cart::make()->lineItems([
+            [
+                'product' => 'product-id',
+                'quantity' => 1,
+                'unit_price' => 500,
+                'tax_breakdown' => [
+                    ['rate' => 20, 'description' => 'VAT', 'zone' => 'uk', 'amount' => 100],
+                ],
+            ],
+        ]);
+
+        $cart = app(ResetTotals::class)->handle($cart, fn ($cart) => $cart);
+
+        $lineItem = $cart->lineItems()->first();
+
+        $this->assertFalse($lineItem->has('tax_breakdown'));
+        $this->assertNull($lineItem->get('tax_breakdown'));
     }
 }


### PR DESCRIPTION
## Problem

When a cart qualifies for a discount and then stops qualifying, `discount_total` is correctly recalculated to zero, but the previously stored `discount_breakdown` is left on the cart. The cart and checkout then render a phantom discount line with a stale amount, even though no discount is actually applied.

`ApplyDiscounts` is the only writer of `discount_breakdown` and only sets it when at least one discount applies (it early returns otherwise). `ResetTotals` clears the analogous `shipping_tax_breakdown` and the per line item `tax_breakdown` on every recalculation, but it does not clear `discount_breakdown`, so a stale breakdown survives.

This surfaced for us with a quantity based discount. A customer briefly added a very large quantity, which baked a large amount into `discount_breakdown`, then reduced the quantity back down. The checkout kept showing a large phantom discount (a value in the thousands) while the charged total was correct.

## Fix

Clear `discount_breakdown` in `ResetTotals`, alongside the existing breakdown resets, so it is rebuilt from scratch on every calculation. `ApplyDiscounts` re-adds it whenever a discount genuinely applies.

## Tests

Added `tests/Cart/Calculator/ResetTotalsTest.php` covering that a stale `discount_breakdown` is cleared on recalculation. I verified it fails without this change and passes with it, and the existing `ApplyDiscountsTest` still passes.

Fixes #234
