### PR TITLE
Dispatch OrderStatusUpdated event for Eloquent orders

### DIFF
--- a/src/Cart/Eloquent/Cart.php
+++ b/src/Cart/Eloquent/Cart.php
@@ -36,7 +36,8 @@ class Cart extends StacheCart
             ->data([
                 ...$model->data ?? [],
                 'updated_at' => $model->updated_at,
-            ]);
+            ])
+            ->syncOriginal();
     }
 
     public static function makeModelFromContract(CartContract $source): CartModel

--- a/src/Discounts/Eloquent/Discount.php
+++ b/src/Discounts/Eloquent/Discount.php
@@ -19,7 +19,8 @@ class Discount extends StacheDiscount
             ->data([
                 ...$model->data ?? [],
                 'updated_at' => $model->updated_at,
-            ]);
+            ])
+            ->syncOriginal();
     }
 
     public static function makeModelFromContract(DiscountContract $source): DiscountModel

--- a/src/Orders/Eloquent/Order.php
+++ b/src/Orders/Eloquent/Order.php
@@ -40,7 +40,8 @@ class Order extends StacheOrder
             ->data([
                 ...$model->data ?? [],
                 'updated_at' => $model->updated_at,
-            ]);
+            ])
+            ->syncOriginal();
     }
 
     public static function makeModelFromContract(OrderContract $source): OrderModel

--- a/tests/Orders/Eloquent/OrderRepositoryTest.php
+++ b/tests/Orders/Eloquent/OrderRepositoryTest.php
@@ -2,10 +2,13 @@
 
 namespace Tests\Orders\Eloquent;
 
+use DuncanMcClean\Cargo\Events\OrderStatusUpdated;
+use DuncanMcClean\Cargo\Orders\OrderStatus;
 use DuncanMcClean\Cargo\Facades\Cart;
 use DuncanMcClean\Cargo\Facades\Order;
 use DuncanMcClean\Cargo\Orders\Eloquent\OrderModel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Statamic;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
@@ -128,6 +131,39 @@ class OrderRepositoryTest extends TestCase
         $this->assertNotNull($order->id());
         $this->assertEquals(1, $order->orderNumber());
         $this->assertNotNull($order->date());
+    }
+
+    #[Test]
+    public function order_status_updated_event_is_dispatched_when_status_changes_on_an_order()
+    {
+        Cart::make()->id('abc')->save();
+
+        $model = OrderModel::create([
+            'order_number' => 1234,
+            'date' => now(),
+            'site' => 'default',
+            'cart' => 'abc',
+            'status' => 'payment_pending',
+            'customer' => json_encode(['name' => 'CJ Cregg', 'email' => 'cj.cregg@whitehouse.gov']),
+            'grand_total' => 2500,
+            'sub_total' => 2500,
+            'discount_total' => 0,
+            'tax_total' => 0,
+            'shipping_total' => 0,
+            'data' => ['foo' => 'bar'],
+        ]);
+
+        $order = $this->repo->find($model->id);
+
+        Event::fake();
+
+        $order->status(OrderStatus::PaymentReceived)->save();
+
+        Event::assertDispatched(OrderStatusUpdated::class, function ($event) use ($order) {
+            return $event->order->id() === $order->id()
+                && $event->originalStatus === OrderStatus::PaymentPending
+                && $event->updatedStatus === OrderStatus::PaymentReceived;
+        });
     }
 
     #[Test]

--- a/tests/Orders/Eloquent/OrderRepositoryTest.php
+++ b/tests/Orders/Eloquent/OrderRepositoryTest.php
@@ -3,10 +3,10 @@
 namespace Tests\Orders\Eloquent;
 
 use DuncanMcClean\Cargo\Events\OrderStatusUpdated;
-use DuncanMcClean\Cargo\Orders\OrderStatus;
 use DuncanMcClean\Cargo\Facades\Cart;
 use DuncanMcClean\Cargo\Facades\Order;
 use DuncanMcClean\Cargo\Orders\Eloquent\OrderModel;
+use DuncanMcClean\Cargo\Orders\OrderStatus;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Test;


### PR DESCRIPTION
This pull request fixes an issue where the `OrderStatusUpdated` event isn't dispatched when an existing order's status changes, when orders are stored using the Eloquent driver.

This was happening because `Order::save()` compares the current status against the order's original status (via Statamic's dirty state) to decide whether to dispatch the event. For file-backed orders, Statamic syncs the original state when loading from the Stache, but the Eloquent driver's `fromModel()` hydration never called `syncOriginal()`. As a result, freshly loaded Eloquent orders had no original state, so the status comparison always failed and the event was skipped.

This PR fixes it by calling `syncOriginal()` at the end of `fromModel()`. I've also applied the same fix to the Eloquent `Cart` and `Discount` classes for consistency.

Fixes #236