### PR TITLE
Don't corrupt `Site::current()` when resolving the cart's site

### DIFF
--- a/src/Stache/Repositories/CartRepository.php
+++ b/src/Stache/Repositories/CartRepository.php
@@ -135,10 +135,6 @@ class CartRepository implements RepositoryContract
 
     private function determineSiteFromRequest(): \Statamic\Sites\Site
     {
-        Site::resolveCurrentUrlUsing(function () {
-            return request()->header('referer');
-        });
-
-        return Site::current();
+        return Site::findByUrl(request()->header('referer')) ?? Site::current();
     }
 }

--- a/tests/Stache/Repositories/CartRepositoryTest.php
+++ b/tests/Stache/Repositories/CartRepositoryTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Stache\Repositories;
 
 use DuncanMcClean\Cargo\Facades\Cart;
+use Illuminate\Http\Request;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
+use Statamic\Facades\Site;
 use Statamic\Facades\YAML;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -101,6 +103,53 @@ class CartRepositoryTest extends TestCase
             'quantity' => 1,
             'total' => 2500,
         ], $yaml['line_items'][0]);
+    }
+
+    /**
+     * @see https://github.com/duncanmcclean/statamic-cargo/issues/240
+     */
+    #[Test]
+    public function it_determines_the_cart_site_from_the_referer_header()
+    {
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'nl' => ['name' => 'Dutch', 'locale' => 'nl_NL', 'url' => 'http://test.com/nl/'],
+        ]);
+
+        $request = Request::create('http://test.com/', 'GET');
+        $request->headers->set('referer', 'http://test.com/nl/products');
+        $this->app->instance('request', $request);
+        $this->repo->forgetCurrentCart();
+
+        $cart = $this->repo->current();
+
+        $this->assertEquals('nl', $cart->site()->handle());
+    }
+
+    /**
+     * @see https://github.com/duncanmcclean/statamic-cargo/issues/240
+     */
+    #[Test]
+    public function resolving_the_current_cart_does_not_corrupt_the_current_site()
+    {
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'nl' => ['name' => 'Dutch', 'locale' => 'nl_NL', 'url' => 'http://test.com/nl/'],
+        ]);
+
+        // We're on the English site, having navigated here from a page on the Dutch site.
+        $request = Request::create('http://test.com/', 'GET');
+        $request->headers->set('referer', 'http://test.com/nl/language-switcher');
+        $this->app->instance('request', $request);
+        $this->repo->forgetCurrentCart();
+
+        $this->assertEquals('en', Site::current()->handle());
+
+        // Rendering the cart (eg. a cart partial in the layout) must not repoint
+        // Site::current() at the referer header for the rest of the request.
+        $this->repo->current();
+
+        $this->assertEquals('en', Site::current()->handle());
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where resolving the current cart permanently corrupts `Site::current()` for the rest of the request, causing tags like `{{ nav:main }}` to render the wrong site's content on multi-site installs.

This was happening because `CartRepository::determineSiteFromRequest()` called `Site::resolveCurrentUrlUsing()` to detect the cart's site from the `Referer` header. That method sets a closure on the `Sites` singleton which is then used for *every* subsequent `Site::current()` call — not just the one inside the method. So once anything on the page touched the cart (eg. a `{{ cart }}` partial in the layout), `Site::current()` was permanently repointed at the `Referer` header. On a direct visit there's no referer, so it fell back to the default (first) site; and when navigating via a language switcher, the referer pointed at the *previous* page, making the nav render the site you'd just come from.

This PR fixes it by resolving the site locally with `Site::findByUrl()` instead of mutating the shared resolver, so the referer lookup can no longer leak into unrelated tags rendered later in the same request.

Fixes #240