### PR TITLE
Re-resolve shipping option price when recalculating totals

### DIFF
--- a/src/Cart/Calculator/ApplyShipping.php
+++ b/src/Cart/Calculator/ApplyShipping.php
@@ -10,7 +10,7 @@ class ApplyShipping
     public function handle(Cart $cart, Closure $next)
     {
         $shippingMethod = $cart->shippingMethod();
-        $shippingOption = $cart->shippingOption();
+        $shippingOption = $shippingMethod?->options($cart)->firstWhere('handle', $cart->shippingOption()?->handle());
 
         if (! $shippingMethod || ! $shippingOption) {
             $cart->remove('shipping_method')->remove('shipping_option');

--- a/tests/Cart/Calculator/ApplyShippingTest.php
+++ b/tests/Cart/Calculator/ApplyShippingTest.php
@@ -5,18 +5,28 @@ namespace Tests\Cart\Calculator;
 use DuncanMcClean\Cargo\Cart\Calculator\ApplyShipping;
 use DuncanMcClean\Cargo\Facades\Cart;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\Fixtures\ShippingMethods\DynamicShipping;
 use Tests\Fixtures\ShippingMethods\PaidShipping;
 use Tests\TestCase;
 
 class ApplyShippingTest extends TestCase
 {
+    use PreventsSavingStacheItemsToDisk;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         PaidShipping::register();
+        DynamicShipping::register();
 
-        config()->set('statamic.cargo.shipping.methods', ['paid_shipping' => []]);
+        config()->set('statamic.cargo.shipping.methods', [
+            'paid_shipping' => [],
+            'dynamic_shipping' => [],
+        ]);
     }
 
     #[Test]
@@ -56,5 +66,36 @@ class ApplyShippingTest extends TestCase
         $this->assertFalse($cart->has('shipping_option'));
 
         $this->assertEquals(0, $cart->shippingTotal());
+    }
+
+    #[Test]
+    public function reresolves_shipping_price_when_option_is_already_saved_to_the_cart()
+    {
+        // ApplyShipping persists the selected option (with its price) on every calculation.
+        // On a later recalculation, after the cart contents have changed, the price must
+        // be resolved from the shipping method to avoid stale prices.
+        Collection::make('products')->save();
+        $product = tap(Entry::make()->collection('products')->data(['price' => 1000]))->save();
+
+        $cart = Cart::make()->data([
+            'shipping_method' => 'dynamic_shipping',
+            'shipping_option' => [
+                'name' => 'Dynamic Option',
+                'handle' => 'dynamic_option',
+                'price' => 100,
+                'accepts_payment_on_delivery' => false,
+            ],
+        ]);
+
+        $cart->lineItems([
+            ['id' => 'a', 'product' => $product->id(), 'quantity' => 1],
+            ['id' => 'b', 'product' => $product->id(), 'quantity' => 1],
+            ['id' => 'c', 'product' => $product->id(), 'quantity' => 1],
+        ]);
+
+        $cart = app(ApplyShipping::class)->handle($cart, fn ($cart) => $cart);
+
+        $this->assertEquals(300, $cart->shippingTotal());
+        $this->assertEquals(300, $cart->get('shipping_option')['price']);
     }
 }

--- a/tests/__fixtures__/app/ShippingMethods/DynamicShipping.php
+++ b/tests/__fixtures__/app/ShippingMethods/DynamicShipping.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Fixtures\ShippingMethods;
+
+use DuncanMcClean\Cargo\Contracts\Cart\Cart as CartContract;
+use DuncanMcClean\Cargo\Shipping\ShippingMethod;
+use DuncanMcClean\Cargo\Shipping\ShippingOption;
+use Illuminate\Support\Collection;
+
+class DynamicShipping extends ShippingMethod
+{
+    public function options(CartContract $cart): Collection
+    {
+        // Price depends on the current cart contents (100 per line item).
+        $price = 100 * max(1, $cart->lineItems()->count());
+
+        return collect([
+            ShippingOption::make($this)
+                ->name('Dynamic Option')
+                ->handle('dynamic_option')
+                ->price($price),
+        ]);
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where the selected shipping option's price wasn't recalculated when the rest of the cart was recalculated. It only happened once a shipping option had already been saved to the cart, meaning changing the cart contents would leave the shipping total stuck at its old price.

This was happening because `ApplyShipping` persists the selected option to the cart as an array (including its price) on every calculation. On a later recalculation, `Cart::shippingOption()` rebuilds the option from that stored array and reuses the saved price, rather than re-resolving it from the shipping method. So the shipping method never got a chance to re-quote against the updated cart.

This PR fixes it by re-resolving the option from the shipping method (by handle) each time shipping is applied, so its price always reflects the current cart. If the previously-selected option is no longer offered, the shipping keys are removed as before.