### PR TITLE
Don't include the current time in the cart fingerprint

### DIFF
--- a/src/Cart/Cart.php
+++ b/src/Cart/Cart.php
@@ -320,7 +320,6 @@ class Cart implements Arrayable, ArrayAccess, Augmentable, ContainsQueryableValu
     public function fingerprint(): string
     {
         $payload = [
-            'date' => Carbon::now()->timestamp,
             'customer' => $this->customer(),
             'discount_code' => $this->get('discount_code'),
             'line_items' => $this->lineItems()->map->toArray()->all(),

--- a/tests/Cart/CartTest.php
+++ b/tests/Cart/CartTest.php
@@ -48,8 +48,6 @@ class CartTest extends TestCase
     #[Test]
     public function does_not_recalculate_totals_when_nothing_has_changed()
     {
-        $this->freezeSecond();
-
         Collection::make('products')->save();
         Entry::make()->id('product-id')->collection('products')->data(['price' => 500])->save();
 


### PR DESCRIPTION
This pull request fixes an issue where a cart would be recalculated on almost every save, even when nothing about it had changed.

This was happening because the cart's fingerprint included the current timestamp (`date`). The fingerprint is meant to detect whether anything meaningful has changed since the last calculation, but since the timestamp changed every second, the fingerprint differed on every subsequent request - so `shouldRecalculate()` almost always returned `true`. 

This PR fixes it by removing `date` from the fingerprint, so it only changes when something that actually affects the cart's totals changes (line items, shipping, address, tax config, etc.).