### PR TITLE
Eager load line items and add indexes to `cargo_orders` table

### DIFF
--- a/src/Commands/stubs/create_orders_table.php.stub
+++ b/src/Commands/stubs/create_orders_table.php.stub
@@ -14,13 +14,13 @@ return new class extends Migration
     public function up()
     {
         Schema::create('ORDERS_TABLE', function (Blueprint $table) {
-            $table->uuid('id');
+            $table->uuid('id')->unique();
             $table->integer('order_number')->autoIncrement();
-            $table->timestamp('date');
-            $table->string('site');
+            $table->timestamp('date')->index();
+            $table->string('site')->index();
             $table->string('cart')->nullable();
-            $table->string('status');
-            $table->string('customer');
+            $table->string('status')->index();
+            $table->string('customer')->index();
             $table->bigInteger('grand_total');
             $table->bigInteger('sub_total');
             $table->bigInteger('discount_total');

--- a/src/Orders/Eloquent/OrderRepository.php
+++ b/src/Orders/Eloquent/OrderRepository.php
@@ -13,7 +13,7 @@ class OrderRepository extends Stache\Repositories\OrderRepository implements Rep
 {
     public function query(): QueryBuilder
     {
-        return app(QueryBuilder::class, ['builder' => app('cargo.orders.eloquent.model')::query()]);
+        return app(QueryBuilder::class, ['builder' => app('cargo.orders.eloquent.model')::query()->with('lineItems')]);
     }
 
     public function save(Order $order): void

--- a/tests/__fixtures__/migrations/0000_00_00_000000_create_orders_table.php
+++ b/tests/__fixtures__/migrations/0000_00_00_000000_create_orders_table.php
@@ -14,13 +14,13 @@ return new class extends Migration
     public function up()
     {
         Schema::create('cargo_orders', function (Blueprint $table) {
-            $table->uuid('id');
+            $table->uuid('id')->unique();
             $table->integer('order_number')->autoIncrement();
-            $table->timestamp('date');
-            $table->string('site');
+            $table->timestamp('date')->index();
+            $table->string('site')->index();
             $table->string('cart')->nullable();
-            $table->string('status');
-            $table->string('customer');
+            $table->string('status')->index();
+            $table->string('customer')->index();
             $table->bigInteger('grand_total');
             $table->bigInteger('sub_total');
             $table->bigInteger('discount_total');


### PR DESCRIPTION
This pull request makes a few performance improvements when storing orders in the database:

- Line items are now eager loaded, to avoid a separate query being run for every order to fetch its line items
- The `cargo_orders` table previously had no indexes. This PR adds indexes to the `id`, `date`, `site`, `status` and `customer` columns.

Related: #238