### PR TITLE
Make Eloquent cart deletion null-safe

### DIFF
--- a/src/Cart/Eloquent/CartRepository.php
+++ b/src/Cart/Eloquent/CartRepository.php
@@ -47,7 +47,7 @@ class CartRepository extends Stache\Repositories\CartRepository implements Repos
 
     public function delete(Cart $cart): void
     {
-        $cart->model()->delete();
+        $cart->model()?->delete();
     }
 
     public static function bindings(): array

--- a/tests/Cart/Eloquent/CartRepositoryTest.php
+++ b/tests/Cart/Eloquent/CartRepositoryTest.php
@@ -144,4 +144,18 @@ class CartRepositoryTest extends TestCase
             'site' => 'default',
         ]);
     }
+
+    #[Test]
+    public function can_delete_a_cart_that_has_not_been_saved()
+    {
+        // A cart that was never persisted has no underlying model. This happens when
+        // the current cart cookie references a cart that no longer exists, so
+        // Cart::current() falls back to a fresh, unsaved cart. Deleting it should be
+        // a no-op rather than throwing "Call to a member function delete() on null".
+        $cart = Cart::make();
+
+        $this->assertNull($cart->model());
+
+        $this->repo->delete($cart);
+    }
 }


### PR DESCRIPTION
### Summary

Fixes #246.

Under the Eloquent cart driver, logging a customer in can fatal with `Call to a member function delete() on null` when their current cart cookie is stale.

`AssignUserToCart` takes the merge branch and calls `$currentCart->delete()`. When the `cargo-cart` cookie references a cart that no longer exists, `Cart::current()` falls back to an unsaved cart with no model (`hasCurrentCart()` still returns true from the cookie), so `CartRepository::delete()` calls `->delete()` on a null model.

### Change

`src/Cart/Eloquent/CartRepository.php`

```diff
-        $cart->model()->delete();
+        $cart->model()?->delete();
```

Deleting a cart that was never persisted is now a no-op, which is the correct behaviour.

### Test

Adds `can_delete_a_cart_that_has_not_been_saved` to `tests/Cart/Eloquent/CartRepositoryTest.php`. It fails on the current code with the reported error and passes with the fix.
