### PR TITLE
Make Stripe capture method configurable

### DIFF
--- a/docs/docs/payment-gateways.md
+++ b/docs/docs/payment-gateways.md
@@ -314,6 +314,24 @@ Stripe::paymentDescription(function (Order $order) {
 });
 ```
 
+### Capture Method
+By default, Cargo authorises payments and captures them separately to ensure customers are only charged once their order has been successfully created. If the checkout process fails, the authorisation is released rather than refunded.
+
+However, not all payment methods support this approach. For example, iDEAL requires the payment to be captured immediately. To support this, you can change the capture method to `automatic` in your config:
+
+```php
+// config/statamic/cargo.php
+
+'stripe' => [
+    'key' => env('STRIPE_KEY'),
+    'secret' => env('STRIPE_SECRET'),
+    'webhook_secret' => env('STRIPE_WEBHOOK_SECRET'),
+    'capture_method' => 'automatic', // [tl! add]
+],
+```
+
+With automatic capture, the payment will be immediately refunded if the checkout fails.
+
 ## Mollie
 ### Payment Form
 :::tip note

--- a/src/Payments/Gateways/Stripe.php
+++ b/src/Payments/Gateways/Stripe.php
@@ -75,7 +75,7 @@ class Stripe extends PaymentGateway
             'customer' => $stripeCustomerId,
             'metadata' => ['cart_id' => $cart->id()],
             'automatic_payment_methods' => ['enabled' => true],
-            'capture_method' => 'manual',
+            'capture_method' => $this->config()->get('capture_method', 'manual'),
         ];
 
         $paymentIntent = PaymentIntent::create($intentData);
@@ -120,7 +120,11 @@ class Stripe extends PaymentGateway
     {
         $paymentIntent = PaymentIntent::retrieve($cart->get('stripe_payment_intent'));
 
-        $paymentIntent->cancel();
+        if ($paymentIntent->status === PaymentIntent::STATUS_SUCCEEDED) {
+            Refund::create(['payment_intent' => $paymentIntent->id]);
+        } else {
+            $paymentIntent->cancel();
+        }
 
         $cart->remove('stripe_payment_intent')->save();
     }

--- a/tests/Payments/StripeTest.php
+++ b/tests/Payments/StripeTest.php
@@ -17,6 +17,7 @@ use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
 use Stripe\Charge;
 use Stripe\Customer;
 use Stripe\PaymentIntent;
+use Stripe\Refund;
 use Tests\TestCase;
 
 #[Group('payments')]
@@ -58,7 +59,22 @@ class StripeTest extends TestCase
 
         $this->assertEquals(1000, $stripePaymentIntent->amount);
         $this->assertEquals('requires_payment_method', $stripePaymentIntent->status);
+        $this->assertEquals('manual', $stripePaymentIntent->capture_method);
         $this->assertEquals(['cart_id' => $cart->id()], $stripePaymentIntent->metadata->toArray());
+    }
+
+    #[Test]
+    public function it_can_setup_a_payment_with_a_configured_capture_method()
+    {
+        config()->set('statamic.cargo.payments.gateways.stripe.capture_method', 'automatic');
+
+        $cart = $this->makeCartWithGuestCustomer();
+
+        (new Stripe)->setup($cart);
+
+        $stripePaymentIntent = PaymentIntent::retrieve($cart->get('stripe_payment_intent'));
+
+        $this->assertEquals('automatic', $stripePaymentIntent->capture_method);
     }
 
     #[Test]
@@ -174,6 +190,32 @@ class StripeTest extends TestCase
 
         $stripePaymentIntent = PaymentIntent::retrieve($stripePaymentIntent->id);
         $this->assertEquals('canceled', $stripePaymentIntent->status);
+    }
+
+    #[Test]
+    public function it_refunds_when_cancelling_an_already_captured_payment()
+    {
+        $stripePaymentIntent = PaymentIntent::create([
+            'amount' => 1000,
+            'currency' => 'gbp',
+            'confirm' => true,
+            'payment_method' => 'pm_card_visa',
+            'automatic_payment_methods' => ['enabled' => true, 'allow_redirects' => 'never'],
+        ]);
+
+        $this->assertEquals('succeeded', $stripePaymentIntent->status);
+
+        $cart = $this->makeCartWithGuestCustomer();
+        $cart->set('stripe_payment_intent', $stripePaymentIntent->id)->save();
+
+        (new Stripe)->cancel($cart);
+
+        $cart->fresh();
+        $this->assertFalse($cart->has('stripe_payment_intent'));
+
+        $refunds = Refund::all(['payment_intent' => $stripePaymentIntent->id]);
+        $this->assertCount(1, $refunds->data);
+        $this->assertEquals(1000, $refunds->data[0]->amount);
     }
 
     #[Test]


### PR DESCRIPTION
This pull request makes Stripe's `capture_method` configurable, defaulting to `manual` so existing installations are unaffected.

By default, Cargo authorises payments and captures them separately, which limits checkout to payment methods that support separate authorisation and capture. This means methods like iDEAL aren't available. Setting `capture_method` to `automatic` in the gateway config now unlocks those methods.

This PR also fixes the cancellation path for automatic capture. Previously, `cancel()` always called `$paymentIntent->cancel()`, which throws an error when the payment has already been captured. Now, when the payment intent has already succeeded, a refund is issued instead — so a failed checkout releases the customer's money rather than erroring.

Related: #250