### PR TITLE
Fix incorrect payment status when migrating orders

### DIFF
--- a/src/Commands/Migration/MigrateOrders.php
+++ b/src/Commands/Migration/MigrateOrders.php
@@ -203,11 +203,11 @@ class MigrateOrders extends Command
 
     private function createOrderFromData(IlluminateCollection $data): OrderContract
     {
-        $status = match ($data->get('order_status')) {
-            'placed' && $data->get('payment_status') === 'paid' => 'payment_received',
-            'placed' => 'payment_pending',
-            'dispatched', 'delivered' => 'shipped',
-            'cancelled' => 'cancelled',
+        $status = match (true) {
+            $data->get('order_status') === 'placed' && $data->get('payment_status') === 'paid' => 'payment_received',
+            $data->get('order_status') === 'placed' => 'payment_pending',
+            in_array($data->get('order_status'), ['dispatched', 'delivered']) => 'shipped',
+            $data->get('order_status') === 'cancelled' => 'cancelled',
         };
 
         $paymentGateway = isset($data->get('gateway')['use'])


### PR DESCRIPTION
This pull request fixes an issue where paid orders were migrated from Simple Commerce with a `payment_pending` status instead of `payment_received`.

This was happening because the `match` expression was matching against `order_status` (a string), but the first arm was a boolean condition (`'placed' && $data->get('payment_status') === 'paid'`). Since `match` uses strict comparison, the string `order_status` never matched the boolean, so the `payment_received` arm never ran and paid orders fell through to `payment_pending`.

This PR fixes it by switching to `match (true)` so each arm is evaluated as a proper condition.

Fixes #252