### PR TITLE
Fix duplicate field exception when overriding a default `product_variants` option field

### DIFF
--- a/src/Fieldtypes/ProductVariants.php
+++ b/src/Fieldtypes/ProductVariants.php
@@ -176,6 +176,8 @@ class ProductVariants extends Fieldtype
 
     public function optionFields(): Fields
     {
+        $configuredOptionFields = collect($this->config('option_fields', []));
+
         $fields = collect([
             [
                 'handle' => 'key',
@@ -213,7 +215,8 @@ class ProductVariants extends Fieldtype
                 ],
             ],
         ])
-            ->merge($this->config('option_fields', []))
+            ->reject(fn ($field) => $configuredOptionFields->keyBy('handle')->has($field['handle']))
+            ->merge($configuredOptionFields)
             ->when($this->config('localizable', false), function ($fields) {
                 return $fields->map(function (array $field) {
                     $field['field']['localizable'] = true;

--- a/tests/Fieldtypes/ProductVariantsFieldtypeTest.php
+++ b/tests/Fieldtypes/ProductVariantsFieldtypeTest.php
@@ -210,4 +210,30 @@ class ProductVariantsFieldtypeTest extends TestCase
             'product_variants.options.*.size' => ['required', 'min:10', 'max:20'],
         ], $extraRules);
     }
+
+    #[Test]
+    public function can_override_a_default_option_field_via_config()
+    {
+        $optionFields = (new ProductVariants)
+            ->setField(new Field('product_variants', [
+                'option_fields' => [
+                    [
+                        'handle' => 'price',
+                        'field' => [
+                            'type' => 'money',
+                            'display' => 'Price',
+                            'validate' => ['required', 'numeric'],
+                        ],
+                    ],
+                ],
+            ]))
+            ->optionFields();
+
+        $this->assertEquals(['key', 'variant', 'price'], $optionFields->all()->keys()->all());
+
+        $this->assertEquals(
+            ['required', 'numeric'],
+            $optionFields->get('price')->get('validate')
+        );
+    }
 }

--- a/tests/Products/ProductVariantTest.php
+++ b/tests/Products/ProductVariantTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Products;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ProductVariantTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Collection::make('products')->save();
+    }
+
+    protected function tearDown(): void
+    {
+        Collection::find('products')?->entryBlueprint()?->delete();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function blueprint_does_not_throw_when_a_default_option_field_has_been_overridden()
+    {
+        Collection::find('products')->entryBlueprint()->ensureField('product_variants', [
+            'type' => 'product_variants',
+            'option_fields' => [
+                [
+                    'handle' => 'price',
+                    'field' => [
+                        'type' => 'money',
+                        'display' => 'Price',
+                        'validate' => ['required', 'numeric'],
+                    ],
+                ],
+            ],
+        ])->save();
+
+        $product = tap(Entry::make()->collection('products')->data(['product_variants' => [
+            'variants' => [['name' => 'Colour', 'values' => ['Red']]],
+            'options' => [['key' => 'Red', 'variant' => 'Red', 'price' => 1000]],
+        ]]))->save();
+
+        $blueprint = $product->variant('Red')->blueprint();
+
+        $this->assertEquals(['key', 'variant', 'price'], $blueprint->fields()->all()->keys()->all());
+        $this->assertEquals(['required', 'numeric'], $blueprint->field('price')->get('validate'));
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where adding a custom `option_fields` entry with the same handle as one of the built-in defaults (`key`, `variant`, or `price`) on the `product_variants` fieldtype throws a `DuplicateFieldException`.

This was happening because `ProductVariants::optionFields()` merged the user's configured `option_fields` onto the built-in defaults using `Collection::merge()`, which appends rather than overriding by handle. If a user added their own `price` field (eg. to add `numeric` validation), the resulting field list ended up with two entries both handled `price`, which threw once the blueprint's fields were resolved.

This PR fixes it by rejecting any built-in default field whose handle is already present in the user's configured `option_fields` before merging, so the user's version wins instead of duplicating.

Fixes #261