### PR TITLE
Add ability to customize JSON API responses

### DIFF
--- a/docs/frontend/json-api/introduction.md
+++ b/docs/frontend/json-api/introduction.md
@@ -4,3 +4,43 @@ title: "JSON API: Introduction"
 When the `<form>` tag just doesn't cut it anymore, Cargo provides a JSON API allowing you to interact with the cart in a more flexible way.
 
 You can do everything you would normally do with the form tags, but just with JSON instead. Particularly useful if you don't want a page reload after submitting forms.
+
+## Customizing Responses
+By default, cart responses include every augmented value from the cart, plus every augmented value from each line item's product. If your product blueprints contain a lot of fields, you may wish to slim down the response.
+
+To do this, create your own resource class, extending Cargo's `CartResource`, and return only the values you need:
+
+```php
+namespace App\Http\Resources;
+
+use DuncanMcClean\Cargo\Http\Resources\API\CartResource;
+
+class SlimCartResource extends CartResource
+{
+    public function toArray($request)
+    {
+        return $this->resource
+            ->toAugmentedCollection(['id', 'grand_total', 'line_items'])
+            ->withShallowNesting()
+            ->toArray();
+    }
+}
+```
+
+Then, tell Cargo to use your resource class by calling `Resource::map` in your `AppServiceProvider`'s `boot` method:
+
+```php
+use App\Http\Resources\SlimCartResource;
+use DuncanMcClean\Cargo\Http\Resources\API\CartResource;
+use DuncanMcClean\Cargo\Http\Resources\API\Resource;
+
+Resource::map([
+    CartResource::class => SlimCartResource::class,
+]);
+```
+
+Cargo will then use your resource class whenever it returns the cart, including from the [Current Cart](/frontend/json-api/endpoints#current-cart) and line item endpoints.
+
+:::tip warning
+Customizing the response may break parts of the [pre-built checkout](/frontend/checkout/introduction) process, as it relies on values from the JSON response. Before removing a value, do a "find in files" across your project to make sure nothing is using it.
+:::

--- a/src/Http/Controllers/CartController.php
+++ b/src/Http/Controllers/CartController.php
@@ -18,7 +18,7 @@ class CartController
     {
         throw_if(! Cart::hasCurrentCart(), NotFoundHttpException::class);
 
-        return new CartResource(Cart::current());
+        return app(CartResource::class)::make(Cart::current());
     }
 
     public function update(UpdateCartRequest $request)
@@ -34,7 +34,7 @@ class CartController
         $cart->save();
 
         if ($request->ajax() || $request->wantsJson()) {
-            return new CartResource($cart->fresh());
+            return app(CartResource::class)::make($cart->fresh());
         }
 
         return $request->_redirect && ! URL::isExternalToApplication($request->_redirect)

--- a/src/Http/Controllers/CartLineItemsController.php
+++ b/src/Http/Controllers/CartLineItemsController.php
@@ -40,7 +40,7 @@ class CartLineItemsController
         $cart->save();
 
         if ($request->ajax() || $request->wantsJson()) {
-            return new CartResource($cart->fresh());
+            return app(CartResource::class)::make($cart->fresh());
         }
 
         return $request->_redirect && ! URL::isExternalToApplication($request->_redirect)
@@ -82,7 +82,7 @@ class CartLineItemsController
         $cart->save();
 
         if ($request->ajax() || $request->wantsJson()) {
-            return new CartResource($cart->fresh());
+            return app(CartResource::class)::make($cart->fresh());
         }
 
         return $request->_redirect && ! URL::isExternalToApplication($request->_redirect)
@@ -103,7 +103,7 @@ class CartLineItemsController
         $cart->save();
 
         if ($request->ajax() || $request->wantsJson()) {
-            return new CartResource($cart->fresh());
+            return app(CartResource::class)::make($cart->fresh());
         }
 
         return $request->_redirect && ! URL::isExternalToApplication($request->_redirect)

--- a/src/Http/Resources/API/Resource.php
+++ b/src/Http/Resources/API/Resource.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Http\Resources\API;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Statamic\Exceptions\JsonResourceException;
+
+class Resource
+{
+    const array CARGO_RESOURCES = [
+        CartResource::class,
+    ];
+
+    public static function map(array $resources): void
+    {
+        collect($resources)
+            ->each(fn ($class, $bindable) => static::validateBinding($bindable, $class))
+            ->each(fn ($class, $bindable) => app()->bind($bindable, fn () => $class));
+    }
+
+    public static function mapDefaults(): void
+    {
+        $resources = collect(static::CARGO_RESOURCES)
+            ->reject(fn ($resource) => app()->has($resource))
+            ->keyBy(fn ($resource) => $resource)
+            ->all();
+
+        static::map($resources);
+    }
+
+    private static function validateBinding(string $bindable, string $class): void
+    {
+        if (! in_array($bindable, static::CARGO_RESOURCES)) {
+            throw new JsonResourceException("[{$bindable}] is not a valid Cargo API resource");
+        }
+
+        if (! is_subclass_of($class, JsonResource::class)) {
+            throw new JsonResourceException("[{$class}] must be a subclass of ".JsonResource::class);
+        }
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,6 +11,7 @@ use DuncanMcClean\Cargo\Facades\Order;
 use DuncanMcClean\Cargo\Facades\PaymentGateway;
 use DuncanMcClean\Cargo\Facades\TaxClass;
 use DuncanMcClean\Cargo\Facades\TaxZone;
+use DuncanMcClean\Cargo\Http\Resources\API\Resource;
 use DuncanMcClean\Cargo\Orders\OrderStatus;
 use DuncanMcClean\Cargo\Orders\OrderStatus as OrderStatusEnum;
 use DuncanMcClean\Cargo\Search\DiscountsProvider;
@@ -120,6 +121,7 @@ class ServiceProvider extends AddonServiceProvider
             ->bootNav()
             ->bootPermissions()
             ->bootRouteBindings()
+            ->bootApiResources()
             ->bootGit()
             ->registerBlueprintNamespace()
             ->registerSearchables()
@@ -365,6 +367,13 @@ class ServiceProvider extends AddonServiceProvider
     private function isFrontendBindingEnabled(): bool
     {
         return config('statamic.routes.bindings', false);
+    }
+
+    private function bootApiResources(): self
+    {
+        Resource::mapDefaults();
+
+        return $this;
     }
 
     protected function bootGit(): self

--- a/tests/API/ResourceTest.php
+++ b/tests/API/ResourceTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\API;
+
+use DuncanMcClean\Cargo\Facades\Cart;
+use DuncanMcClean\Cargo\Http\Resources\API\CartResource;
+use DuncanMcClean\Cargo\Http\Resources\API\Resource;
+use Illuminate\Http\Resources\Json\JsonResource;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Exceptions\JsonResourceException;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ResourceTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cart::forgetCurrentCart();
+    }
+
+    #[Test]
+    #[DataProvider('cartEndpointsProvider')]
+    public function cart_endpoints_use_the_default_cart_resource($method, $uri, $params)
+    {
+        $cart = $this->makeCart();
+
+        $this
+            ->{$method}($uri, $params)
+            ->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'customer',
+                    'grand_total',
+                    'line_items',
+                ],
+            ])
+            ->assertJsonPath('data.id', $cart->id());
+    }
+
+    #[Test]
+    #[DataProvider('cartEndpointsProvider')]
+    public function cart_endpoints_use_a_mapped_cart_resource($method, $uri, $params)
+    {
+        Resource::map([
+            CartResource::class => CustomCartResource::class,
+        ]);
+
+        $cart = $this->makeCart();
+
+        $this
+            ->{$method}($uri, $params)
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    'id' => $cart->id(),
+                    'custom' => true,
+                ],
+            ])
+            ->assertJsonMissingPath('data.line_items');
+    }
+
+    public static function cartEndpointsProvider(): array
+    {
+        return [
+            'cart' => ['getJson', '/!/cargo/cart', []],
+            'add line item' => ['postJson', '/!/cargo/cart/line-items', ['product' => 'product-2', 'quantity' => 1]],
+            'update line item' => ['patchJson', '/!/cargo/cart/line-items/line-item-1', ['quantity' => 2]],
+            'remove line item' => ['deleteJson', '/!/cargo/cart/line-items/line-item-1', []],
+        ];
+    }
+
+    #[Test]
+    public function it_throws_when_mapping_an_invalid_resource()
+    {
+        $this->expectException(JsonResourceException::class);
+        $this->expectExceptionMessage('[stdClass] is not a valid Cargo API resource');
+
+        Resource::map([
+            \stdClass::class => CustomCartResource::class,
+        ]);
+    }
+
+    #[Test]
+    public function it_throws_when_mapping_a_class_which_is_not_a_json_resource()
+    {
+        $this->expectException(JsonResourceException::class);
+        $this->expectExceptionMessage('[stdClass] must be a subclass of '.JsonResource::class);
+
+        Resource::map([
+            CartResource::class => \stdClass::class,
+        ]);
+    }
+
+    private function makeCart()
+    {
+        Collection::make('products')->save();
+        Entry::make()->collection('products')->id('product-1')->data(['title' => 'Product 1', 'price' => 1000])->save();
+        Entry::make()->collection('products')->id('product-2')->data(['title' => 'Product 2', 'price' => 500])->save();
+
+        $cart = Cart::make()
+            ->customer(['name' => 'John Doe', 'email' => 'john.doe@example.com'])
+            ->lineItems([
+                [
+                    'id' => 'line-item-1',
+                    'product' => 'product-1',
+                    'quantity' => 1,
+                    'total' => 1000,
+                ],
+            ]);
+
+        $cart->save();
+
+        Cart::setCurrent($cart);
+
+        return $cart;
+    }
+}
+
+class CustomCartResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->resource->id(),
+            'custom' => true,
+        ];
+    }
+}


### PR DESCRIPTION
This pull request implements the ability to swap out the `CartResource` class, which is used to build the JSON responses returned by the cart and line item endpoints.

Previously, the resource was hardcoded in Cargo's controllers, so responses always included every augmented value from the cart, plus every augmented value from each line item's product. When product blueprints contain a lot of fields, this makes for unnecessarily large responses, with no clean way to slim them down without overriding the controllers.

This PR mirrors the [`Resource::map()` pattern](https://statamic.dev/content-api#customizing-resources) from Statamic's Content API: resources are now resolved through the container, and a new `DuncanMcClean\Cargo\Http\Resources\API\Resource` registrar lets apps map their own resource classes.

## Customizing Responses

Create your own resource class, extending Cargo's `CartResource`, and return only the values you need:

```php
namespace App\Http\Resources;

use DuncanMcClean\Cargo\Http\Resources\API\CartResource;

class SlimCartResource extends CartResource
{
    public function toArray($request)
    {
        return $this->resource
            ->toAugmentedCollection(['id', 'grand_total', 'line_items'])
            ->withShallowNesting()
            ->toArray();
    }
}
```

Then, tell Cargo to use your resource class by calling `Resource::map` in your `AppServiceProvider`'s `boot` method:

```php
use App\Http\Resources\SlimCartResource;
use DuncanMcClean\Cargo\Http\Resources\API\CartResource;
use DuncanMcClean\Cargo\Http\Resources\API\Resource;

Resource::map([
    CartResource::class => SlimCartResource::class,
]);
```

Cargo will then use your resource class whenever it returns the cart, including from the Current Cart and line item endpoints.

> [!WARNING]
> Customizing the response may break parts of the pre-built checkout process, as it relies on values from the JSON response. Before removing a value, do a "find in files" across your project to make sure nothing is using it.

---

Related: #264