### PR TITLE
Fix timezone drift on `date` when saving Eloquent orders

### DIFF
--- a/src/Orders/Eloquent/Order.php
+++ b/src/Orders/Eloquent/Order.php
@@ -56,7 +56,7 @@ class Order extends StacheOrder
 
         $attributes = [
             'site' => $source->site()->handle(),
-            'date' => $source->date(),
+            'date' => $source->date()?->copy()->setTimezone(config('app.timezone')),
             'cart' => $source->cart(),
             'status' => $source->status()->value,
             'customer' => $customer,

--- a/src/Orders/Eloquent/OrderRepository.php
+++ b/src/Orders/Eloquent/OrderRepository.php
@@ -21,7 +21,7 @@ class OrderRepository extends Stache\Repositories\OrderRepository implements Rep
         $model = $order->toModel();
 
         if (! $order->date()) {
-            $model->date = Carbon::now('UTC');
+            $model->date = Carbon::now();
         }
 
         $model->save();

--- a/tests/Orders/Eloquent/OrderRepositoryTest.php
+++ b/tests/Orders/Eloquent/OrderRepositoryTest.php
@@ -8,6 +8,7 @@ use DuncanMcClean\Cargo\Facades\Order;
 use DuncanMcClean\Cargo\Orders\Eloquent\OrderModel;
 use DuncanMcClean\Cargo\Orders\OrderStatus;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Statamic;
@@ -131,6 +132,39 @@ class OrderRepositoryTest extends TestCase
         $this->assertNotNull($order->id());
         $this->assertEquals(1, $order->orderNumber());
         $this->assertNotNull($order->date());
+    }
+
+    #[Test]
+    public function date_does_not_shift_when_app_timezone_is_not_utc()
+    {
+        config()->set('app.timezone', 'Europe/Berlin');
+        date_default_timezone_set('Europe/Berlin');
+
+        $date = Carbon::parse('2025-08-18 10:00:00', 'UTC');
+
+        $order = Order::make()
+            ->site('default')
+            ->cart('abc')
+            ->status('payment_pending')
+            ->date($date)
+            ->customer(['name' => 'CJ Cregg', 'email' => 'cj.cregg@whitehouse.gov'])
+            ->grandTotal(2500)
+            ->subTotal(2500)
+            ->discountTotal(0)
+            ->taxTotal(0)
+            ->shippingTotal(0);
+
+        $this->repo->save($order);
+
+        $this->assertTrue($order->date()->equalTo($date));
+
+        $order = $this->repo->find($order->id());
+
+        $this->assertTrue($order->date()->equalTo($date));
+
+        $this->repo->save($order);
+
+        $this->assertTrue($order->date()->equalTo($date));
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where the `date` on Eloquent orders would shift backwards by the timezone offset on every save when the app timezone isn't UTC, often ending up on the previous day.

This was happening because Cargo keeps order dates as UTC Carbon instances in memory, but the UTC Carbon was assigned directly onto the Eloquent model, persisting a UTC wall-clock string without conversion. When the order was read back, the `datetime` cast parsed that string in the app timezone and converted it to UTC again, shifting the date backwards by the offset on every save/read cycle.

This PR fixes it by converting the date to the app timezone before assigning it to the model (matching the behaviour of `created_at`), and by defaulting missing dates to `Carbon::now()` in the app timezone instead of UTC.

Fixes #268
