### PR TITLE
Fix falsy values being dropped from product variant options

### DIFF
--- a/src/Fieldtypes/ProductVariants.php
+++ b/src/Fieldtypes/ProductVariants.php
@@ -86,10 +86,10 @@ class ProductVariants extends Fieldtype
 
         return [
             'variants' => collect(Arr::get($data, 'variants'))
-                ->map(fn ($variant) => $this->variantFields()->addValues($variant)->process()->values()->filter()->all())
+                ->map(fn ($variant) => $this->variantFields()->addValues($variant)->process()->values()->whereNotNull()->all())
                 ->all(),
             'options' => collect(Arr::get($data, 'options'))
-                ->map(fn ($option) => $this->optionFields()->addValues($option)->process()->values()->filter()->all())
+                ->map(fn ($option) => $this->optionFields()->addValues($option)->process()->values()->whereNotNull()->all())
                 ->all(),
         ];
     }

--- a/tests/Fieldtypes/ProductVariantsFieldtypeTest.php
+++ b/tests/Fieldtypes/ProductVariantsFieldtypeTest.php
@@ -80,6 +80,28 @@ class ProductVariantsFieldtypeTest extends TestCase
     }
 
     #[Test]
+    public function can_process_with_falsy_values()
+    {
+        $process = (new ProductVariants)
+            ->setField(new Field('product_variants', [
+                'option_fields' => [
+                    ['handle' => 'stock', 'field' => ['type' => 'integer']],
+                    ['handle' => 'featured', 'field' => ['type' => 'toggle']],
+                ],
+            ]))
+            ->process([
+                'variants' => [['name' => 'Colour', 'values' => ['Red']]],
+                'options' => [
+                    ['key' => 'Red', 'variant' => 'Red', 'price' => '0.00', 'stock' => 0, 'featured' => false],
+                ],
+            ]);
+
+        $this->assertSame(0, $process['options'][0]['price']);
+        $this->assertSame(0, $process['options'][0]['stock']);
+        $this->assertSame(false, $process['options'][0]['featured']);
+    }
+
+    #[Test]
     public function can_process_with_no_variants_and_no_options()
     {
         $process = (new ProductVariants)


### PR DESCRIPTION
This pull request fixes an issue where entering `0` into an integer option field on the Product Variants fieldtype wouldn't save. The edit would silently revert and the CP would warn about unsaved changes when navigating away.

This was happening because `ProductVariants::process()` passed each variant and option through a bare `filter()`, which strips every falsy value. So `0` never made it into the saved data, and the field came back empty in the save response.

This PR fixes it by swapping `filter()` for `whereNotNull()`, so only fields without a value are dropped. As well as integers, this also fixes toggles set to `false` and options priced at `0.00`.