### PR TITLE
Update Release Workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/resources/dist/**/* linguist-generated=true
+/resources/dist-checkout/**/* linguist-generated=true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,29 +1,65 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, without the v prefix (e.g. 1.2.0)'
+        required: true
+        type: string
 
 permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   release:
-    name: Prepare & Create Release
+    name: Create Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # Create releases and upload assets
-      issues: write # Comment on related issues
-      pull-requests: write # Comment on related PRs
+    environment: Releases
+    permissions: {} # all writes go through the App token; GITHUB_TOKEN needs no scopes
     steps:
-      - name: Checkout code
+      - name: Resolve and validate version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          version="${INPUT_VERSION#v}"
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::Version must look like 1.2.0 (got: $INPUT_VERSION)"
+            exit 1
+          fi
+
+          if [[ "$BRANCH" =~ ^[0-9]+\.x$ ]] && [ "${version%%.*}" != "${BRANCH%%.*}" ]; then
+            echo "::error::Version $version does not belong on the $BRANCH branch"
+            exit 1
+          fi
+
+          echo "TAG=v$version" >> "$GITHUB_ENV"
+
+      - name: Get release bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true # zizmor: ignore[artipacked] App token is needed to push the tag
+
+      - name: Assert tag does not already exist
+        run: |
+          existing="$(git ls-remote --tags origin "$TAG")"
+          [ -z "$existing" ] || { echo "::error::Tag $TAG already exists on remote. Aborting."; exit 1; }
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
@@ -31,60 +67,67 @@ jobs:
           php-version: 8.4
           extensions: fileinfo, exif, gd, pdo, sqlite, pdo_sqlite, intl
 
-      - name: Install composer dependencies
-        run: |
-          composer install --prefer-dist --no-interaction --no-suggest
+      - name: Use Node.js 20.19.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20.19.0
+          package-manager-cache: false
 
-      - name: Install npm dependencies
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-interaction --no-suggest
+
+      - name: Install NPM dependencies
         run: npm ci
 
-      - name: Compile assets
+      - name: Build release assets
         run: npm run build
 
-      - name: Compile checkout assets
+      - name: Build checkout assets
         run: npm run checkout-build
 
-      - name: Create dist zip
-        run: cd resources && tar -czvf dist.tar.gz dist
+      - name: Create the build commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git add --force resources/dist resources/dist-checkout
+          git commit -m "Build assets for $TAG"
 
-      - name: Create dist-checkout zip
-        run: cd resources && tar -czvf dist-checkout.tar.gz dist-checkout
+      - name: Tag and push the build commit
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG"
 
       - name: Get Changelog
         id: changelog
-        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1
+        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1.0.2
         with:
-          version: ${{ github.ref }}
-
-      - name: Determine prerelease status
-        id: prerelease
-        env:
-          REF: ${{ github.ref }}
-        run: |
-          if [[ "$REF" == *"-alpha"* ]] || [[ "$REF" == *"-beta"* ]]; then
-            echo "flag=--prerelease" >> $GITHUB_OUTPUT
-          else
-            echo "flag=" >> $GITHUB_OUTPUT
-          fi
+          version: ${{ env.TAG }}
 
       - name: Create release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
-          CHANGELOG: ${{ steps.changelog.outputs.text }}
-          PRERELEASE_FLAG: ${{ steps.prerelease.outputs.flag }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_NOTES: ${{ steps.changelog.outputs.text }}
+          IS_DEFAULT_BRANCH: ${{ github.ref_name == github.event.repository.default_branch }}
         run: |
-          gh release create "$TAG_NAME" \
-            --title "$TAG_NAME" \
-            --notes "$CHANGELOG" \
-            $PRERELEASE_FLAG \
-            ./resources/dist.tar.gz \
-            ./resources/dist-checkout.tar.gz
+          latest="$IS_DEFAULT_BRANCH"
+          prerelease=false
+          case "$TAG" in
+            *-*) prerelease=true; latest=false ;;
+          esac
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "$RELEASE_NOTES" \
+            --latest="$latest" \
+            --prerelease="$prerelease"
 
       - name: Comment on related issues
         uses: duncanmcclean/post-release-comments@ee2d062e73bd6f0898f36ed892953ed88134cc19 # v1.0.6
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          version: ${{ github.ref }}
+          version: ${{ env.TAG }}
           changelog: ${{ steps.changelog.outputs.text }}

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,6 @@
         }
     },
     "extra": {
-        "download-dist": [
-            {
-                "url": "https://github.com/duncanmcclean/statamic-cargo/releases/download/{$version}/dist.tar.gz",
-                "path": "resources/dist"
-            },
-            {
-                "url": "https://github.com/duncanmcclean/statamic-cargo/releases/download/{$version}/dist-checkout.tar.gz",
-                "path": "resources/dist-checkout"
-            }
-        ],
         "statamic": {
             "name": "Cargo",
             "slug": "cargo",
@@ -45,7 +35,6 @@
         "laravel/framework": "^12.0 || ^13.0",
         "mollie/mollie-api-php": "^3.0",
         "moneyphp/money": "^4.5",
-        "pixelfear/composer-dist-plugin": "^0.1.0",
         "statamic/cms": "^6.20",
         "stillat/proteus": "^4.2.1",
         "stripe/stripe-php": "^16.4",
@@ -63,8 +52,7 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "allow-plugins": {
-            "pestphp/pest-plugin": true,
-            "pixelfear/composer-dist-plugin": true
+            "pestphp/pest-plugin": true
         }
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
This pull request updates the addon's release workflow, replacing `pixelfear/composer-dist-plugin` (which fetched compiled assets at install time) with a CI-driven release that builds the assets into the released tag itself. Consumers get the built dist inside the Packagist zip — no post-install fetch.

Related: https://github.com/statamic/cms/pull/14804
