### PR TITLE
Support per-site default tax addresses

### DIFF
--- a/docs/docs/taxes.md
+++ b/docs/docs/taxes.md
@@ -64,6 +64,25 @@ Only the `country`, `state` and `postcode` are used when matching tax zones. As 
 The default address is only used to estimate taxes. Customers still need to provide a real address before they can checkout.
 :::
 
+### Per-site default addresses
+If you're running a [multi-site](/docs/multi-site) store, you can configure a different default address for each site by nesting addresses under site handles:
+
+```php
+// config/statamic/cargo.php
+
+'taxes' => [  
+    'default_address' => [  
+        'country' => 'GBR',
+
+        'ie' => [
+            'country' => 'IRL',
+        ],
+    ],  
+],
+```
+
+Cargo uses the address matching the cart's site. Sites without their own address fall back to the top-level `country`, `state` and `postcode`, so you can omit those if every site has its own address.
+
 ## Templating
 You can display the cart's tax total using `{{ cart:tax_total }}`.
 

--- a/docs/docs/taxes.md
+++ b/docs/docs/taxes.md
@@ -58,7 +58,7 @@ When prices are exclusive of tax, that means customers won't see any tax on the 
 ],
 ```
 
-Only the `country`, `state` and `postcode` are used when matching tax zones. As soon as the customer provides their own address, taxes will be recalculated against it.
+Only the `country`, `state` and `postcode` are used when matching tax zones. The `country` should be a three-letter [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code (eg. `GBR`, not `GB`). As soon as the customer provides their own address, taxes will be recalculated against it.
 
 :::tip note
 The default address is only used to estimate taxes. Customers still need to provide a real address before they can checkout.

--- a/src/Cart/Calculator/CalculateTaxes.php
+++ b/src/Cart/Calculator/CalculateTaxes.php
@@ -7,12 +7,13 @@ use DuncanMcClean\Cargo\Cart\Cart;
 use DuncanMcClean\Cargo\Contracts\Taxes\Driver as TaxDriver;
 use DuncanMcClean\Cargo\Data\Address;
 use DuncanMcClean\Cargo\Orders\LineItem;
+use Illuminate\Support\Arr;
 
 class CalculateTaxes
 {
     public function handle(Cart $cart, Closure $next)
     {
-        $taxableAddress = $cart->taxableAddress() ?? $this->defaultAddress();
+        $taxableAddress = $cart->taxableAddress() ?? $this->defaultAddress($cart);
 
         if (! $taxableAddress) {
             return $next($cart);
@@ -76,9 +77,15 @@ class CalculateTaxes
         return $next($cart);
     }
 
-    private function defaultAddress(): ?Address
+    private function defaultAddress(Cart $cart): ?Address
     {
-        $address = array_filter(config('statamic.cargo.taxes.default_address') ?? []);
+        $defaultAddress = config('statamic.cargo.taxes.default_address') ?? [];
+
+        if (isset($defaultAddress[$cart->site()->handle()])) {
+            $defaultAddress = $defaultAddress[$cart->site()->handle()];
+        }
+
+        $address = array_filter(Arr::only($defaultAddress, ['country', 'state', 'postcode']));
 
         if (empty($address)) {
             return null;

--- a/tests/Cart/Calculator/CalculateTaxesTest.php
+++ b/tests/Cart/Calculator/CalculateTaxesTest.php
@@ -14,6 +14,7 @@ use DuncanMcClean\Cargo\Shipping\ShippingOption;
 use DuncanMcClean\Cargo\Taxes\TaxCalculation;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -189,6 +190,82 @@ class CalculateTaxesTest extends TestCase
         $this->assertEquals(100, $cart->get('shipping_tax_total'));
         $this->assertEquals(600, $cart->shippingTotal());
         $this->assertEquals(2100, $cart->taxTotal());
+    }
+
+    #[Test]
+    #[DataProvider('siteDefaultAddressProvider')]
+    public function calculates_tax_against_site_default_address_when_cart_has_no_address(string $site, array $defaultAddress, string $expectedZone, int $expectedRate, int $expectedAmount)
+    {
+        $this->setSites([
+            'ie' => ['name' => 'Ireland', 'locale' => 'en_IE', 'url' => 'http://test.com/ie/'],
+            'uk' => ['name' => 'United Kingdom', 'locale' => 'en_GB', 'url' => 'http://test.com/'],
+            'us' => ['name' => 'United States', 'locale' => 'en_US', 'url' => 'http://test.com/us/'],
+        ]);
+
+        config()->set('statamic.cargo.taxes.default_address', $defaultAddress);
+
+        $product = Entry::make()->collection('products')->data(['price' => 10000, 'tax_class' => 'standard']);
+        $product->save();
+
+        $cart = Cart::make()
+            ->site($site)
+            ->lineItems([
+                ['id' => 'one', 'product' => $product->id(), 'quantity' => 1, 'total' => 10000],
+            ]);
+
+        TaxZone::make()->handle('ireland')->data([
+            'title' => 'Ireland',
+            'type' => 'countries',
+            'countries' => ['IRL'],
+            'rates' => ['standard' => 23],
+        ])->save();
+
+        TaxZone::make()->handle('uk')->data([
+            'title' => 'UK',
+            'type' => 'countries',
+            'countries' => ['GBR'],
+            'rates' => ['standard' => 20],
+        ])->save();
+
+        TaxZone::make()->handle('usa')->data([
+            'title' => 'USA',
+            'type' => 'countries',
+            'countries' => ['USA'],
+            'rates' => ['standard' => 10],
+        ])->save();
+
+        $cart = app(CalculateTaxes::class)->handle($cart, fn ($cart) => $cart);
+
+        $lineItem = $cart->lineItems()->find('one');
+
+        $this->assertEquals([
+            ['rate' => $expectedRate, 'description' => 'Standard', 'zone' => $expectedZone, 'amount' => $expectedAmount],
+        ], $lineItem->get('tax_breakdown'));
+
+        $this->assertEquals($expectedAmount, $lineItem->taxTotal());
+        $this->assertEquals(10000 + $expectedAmount, $lineItem->total());
+        $this->assertEquals($expectedAmount, $cart->taxTotal());
+    }
+
+    public static function siteDefaultAddressProvider(): array
+    {
+        return [
+            'irish site' => [
+                'ie',
+                ['ie' => ['country' => 'IRL'], 'uk' => ['country' => 'GBR']],
+                'Ireland', 23, 2300,
+            ],
+            'uk site' => [
+                'uk',
+                ['ie' => ['country' => 'IRL'], 'uk' => ['country' => 'GBR']],
+                'UK', 20, 2000,
+            ],
+            'site without its own default address falls back to top-level address' => [
+                'us',
+                ['country' => 'USA', 'ie' => ['country' => 'IRL']],
+                'USA', 10, 1000,
+            ],
+        ];
     }
 
     #[Test]


### PR DESCRIPTION
This pull request implements support for configuring a different default tax address per site.

Previously, `taxes.default_address` was a single address, so multi-site stores couldn't estimate taxes against the right country for each site. This PR fixes it by allowing addresses to be nested under site handles. Cargo will use the address matching the cart's site, falling back to the top-level `country`, `state` and `postcode` for sites without their own address:

```php
'taxes' => [
    'default_address' => [
        'country' => 'GBR',

        'ie' => [
            'country' => 'IRL',
        ],
    ],
],
```

The site is resolved from the cart rather than the current site, so recalculation in queues and the Control Panel picks the correct address.

Related: #272
