### PR TITLE
Publish an "order shipped" email during install

### DIFF
--- a/docs/docs/email-notifications.md
+++ b/docs/docs/email-notifications.md
@@ -1,17 +1,24 @@
 ---
 title: Email Notifications
-description: "Cargo can send email notifications to customers when they place an order. This page explains how to configure Cargo to send emails, and how to preview them in the browser."
+description: "Cargo can send email notifications to customers when they place an order and when it has been shipped. This page explains how to configure Cargo to send emails, and how to preview them in the browser."
 ---
 
-When you install Cargo, it will automatically create a [mailable](https://laravel.com/docs/master/mail) for you, resulting in a class in `app/Mail` and a view in `resources/views/emails`.
+When you install Cargo, it will automatically create two [mailables](https://laravel.com/docs/master/mail) for you, resulting in classes in `app/Mail` and views in `resources/views/emails`:
 
-Cargo will also configure an [event listener](https://laravel.com/docs/master/events#closure-listeners) in your `AppServiceProvider`, trigger the email to send whenever Cargo's [`OrderPaymentReceived`](/docs/events#orderpaymentreceived) event is dispatched.
+| Mailable | Sent when... |
+| --- | --- |
+| `App\Mail\OrderConfirmation` | An order's payment has been received. |
+| `App\Mail\OrderShipped` | An order has been marked as shipped. If a tracking number has been provided, it'll be included in the email. |
+
+Cargo will also configure [event listeners](https://laravel.com/docs/master/events#closure-listeners) in your `AppServiceProvider`, triggering the emails to send whenever Cargo's [`OrderPaymentReceived`](/docs/events#orderpaymentreceived) and [`OrderShipped`](/docs/events#ordershipped) events are dispatched.
 
 ```php
 // app/Providers/AppServiceProvider.php
 
 use App\Mail\OrderConfirmation;
+use App\Mail\OrderShipped;
 use DuncanMcClean\Cargo\Events\OrderPaymentReceived;
+use DuncanMcClean\Cargo\Events\OrderShipped as OrderShippedEvent;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
 
@@ -20,29 +27,39 @@ Event::listen(OrderPaymentReceived::class, function ($event) {
         ->locale($event->order->site()->shortLocale())
         ->send(new OrderConfirmation($event->order));
 });
+
+Event::listen(OrderShippedEvent::class, function ($event) {
+    Mail::to($event->order->customer())
+        ->locale($event->order->site()->shortLocale())
+        ->send(new OrderShipped($event->order));
+});
 ```
 
-To change the content of the email, all you need to do is edit the view or mailable class in your app.
+To change the content of the emails, all you need to do is edit the views or mailable classes in your app.
+
+:::tip note
+If you installed Cargo before the `OrderShipped` mailable was introduced, you can run `php please cargo:install` again to publish it. Any mailables you've already published will be left untouched.
+:::
 
 ## Sending your own emails 
 If you want to send any other emails, you can create your own mailable, then configure an event listener to trigger it based on one of [Cargo's events](/extending/events/list):
 
 ```sh
-php artisan make:mail OrderOnTheWay
+php artisan make:mail OrderCancelled
 ```
 
 ```php
 // app/Providers/AppServiceProvider.php
 
-use App\Mail\OrderOnTheWay;
-use DuncanMcClean\Cargo\Events\OrderShipped;
+use App\Mail\OrderCancelled;
+use DuncanMcClean\Cargo\Events\OrderCancelled as OrderCancelledEvent;
 use Illuminate\Support\Facades\Event;  
 use Illuminate\Support\Facades\Mail;
 
-Event::listen(OrderShipped::class, function ($event) {  
+Event::listen(OrderCancelledEvent::class, function ($event) {  
     Mail::to($event->order->customer())  
         ->locale($event->order->site()->shortLocale())  
-        ->send(new OrderOnTheWay($event->order));  
+        ->send(new OrderCancelled($event->order));  
 });
 ```
 
@@ -59,6 +76,12 @@ Route::get('/order-confirmation', function () {
 
 	return new OrderConfirmation($order);
 });
+
+Route::get('/order-shipped', function () {
+	$order = Order::query()->orderByDesc('date')->first();
+
+	return new OrderShipped($order);
+});
 ```
 
-You may want to wrap the route in a `if (! app()->isProduction())` conditional to ensure the email isn't accessible in production.
+You may want to wrap the routes in a `if (! app()->isProduction())` conditional to ensure the emails aren't accessible in production.

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -152,48 +152,82 @@ class InstallCommand extends Command
 
     private function publishMailables(): self
     {
-        $mailablePath = app_path('Mail/OrderConfirmation.php');
-        $mailableViewPath = resource_path('views/emails/order-confirmation.blade.php');
+        $publishedOrderConfirmation = $this->publishMailable(
+            mailable: 'OrderConfirmation',
+            view: 'order-confirmation',
+            imports: [
+                'App\Mail\OrderConfirmation',
+                'DuncanMcClean\Cargo\Events\OrderPaymentReceived',
+            ],
+            listener: <<<'PHP'
+    Event::listen(OrderPaymentReceived::class, function ($event) {
+            Mail::to($event->order->customer())
+                ->locale($event->order->site()->shortLocale())
+                ->send(new OrderConfirmation($event->order));
+        });
+PHP,
+        );
 
-        if (File::exists($mailablePath) && File::exists($mailableViewPath)) {
+        $publishedOrderShipped = $this->publishMailable(
+            mailable: 'OrderShipped',
+            view: 'order-shipped',
+            imports: [
+                'App\Mail\OrderShipped',
+                'DuncanMcClean\Cargo\Events\OrderShipped' => 'OrderShippedEvent',
+            ],
+            listener: <<<'PHP'
+    Event::listen(OrderShippedEvent::class, function ($event) {
+            Mail::to($event->order->customer())
+                ->locale($event->order->site()->shortLocale())
+                ->send(new OrderShipped($event->order));
+        });
+PHP,
+        );
+
+        if (! $publishedOrderConfirmation && ! $publishedOrderShipped) {
             return $this;
         }
 
+        $this->components->info("Mailables published. You'll find them in <comment>app/Mail</comment> and <comment>resources/views/emails</comment>.");
+
+        return $this;
+    }
+
+    private function publishMailable(string $mailable, string $view, array $imports, string $listener): bool
+    {
+        $mailablePath = app_path("Mail/{$mailable}.php");
+        $mailableViewPath = resource_path("views/emails/{$view}.blade.php");
+
+        if (File::exists($mailablePath) && File::exists($mailableViewPath)) {
+            return false;
+        }
+
         File::ensureDirectoryExists(app_path('Mail'));
-        File::put($mailablePath, File::get(__DIR__.'/stubs/install/OrderConfirmation.php.stub'));
+        File::put($mailablePath, File::get(__DIR__."/stubs/install/{$mailable}.php.stub"));
 
         File::ensureDirectoryExists(resource_path('views/emails'));
-        File::put($mailableViewPath, File::get(__DIR__.'/stubs/install/order-confirmation.blade.php.stub'));
+        File::put($mailableViewPath, File::get(__DIR__."/stubs/install/{$view}.blade.php.stub"));
 
         CodeInjection::injectImports(
             file: app_path('Providers/AppServiceProvider.php'),
             imports: [
                 'Illuminate\Support\Facades\Event',
                 'Illuminate\Support\Facades\Mail',
-                'App\Mail\OrderConfirmation',
-                'DuncanMcClean\Cargo\Events\OrderPaymentReceived',
+                ...$imports,
             ],
         );
 
         try {
-            CodeInjection::injectIntoAppServiceProviderBoot($code = <<<'PHP'
-    Event::listen(OrderPaymentReceived::class, function ($event) {
-            Mail::to($event->order->customer())
-                ->locale($event->order->site()->shortLocale())
-                ->send(new OrderConfirmation($event->order));
-        });
-PHP);
+            CodeInjection::injectIntoAppServiceProviderBoot($listener);
         } catch (\Exception $e) {
             if ($e->getMessage() !== 'Code has already been injected.') {
                 $this->components->warn('Failed to inject code into AppServiceProvider. Please add the following to the <comment>boot</comment> method manually:');
-                $this->line($code);
+                $this->line($listener);
                 $this->newLine();
             }
         }
 
-        $this->components->info("Mailables published. You'll find them in <comment>app/Mail</comment> and <comment>resources/views/emails</comment>.");
-
-        return $this;
+        return true;
     }
 
     private function publishPrebuiltCheckout(): self

--- a/src/Commands/stubs/install/OrderShipped.php.stub
+++ b/src/Commands/stubs/install/OrderShipped.php.stub
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Mail;
+
+use DuncanMcClean\Cargo\Contracts\Orders\Order;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class OrderShipped extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(public Order $order) {}
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "Order #{$this->order->orderNumber()} has been shipped",
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.order-shipped',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/src/Commands/stubs/install/order-shipped.blade.php.stub
+++ b/src/Commands/stubs/install/order-shipped.blade.php.stub
@@ -1,0 +1,30 @@
+<x-mail::message>
+# Order #{{ $order->orderNumber }} has been shipped
+
+Good news! Your order is on its way.
+
+<x-mail::panel>
+@if($order->shippingOption)
+**Shipping Option:** {{ $order->shippingOption()->name() }}
+@endif
+
+@if($order->tracking_number)
+**Tracking Number:** {{ $order->tracking_number }}
+@endif
+
+@if($order->hasShippingAddress())
+**Shipping Address:** {{ $order->shippingAddress() }}
+@endif
+</x-mail::panel>
+
+<x-mail::table>
+| Item Description   |      Quantity |
+| :----------------- | ------------: |
+@foreach($order->lineItems() as $lineItem)
+| {{ $lineItem->product()->title }} | {{ $lineItem->quantity }} |
+@endforeach
+</x-mail::table>
+
+Thank you for your order!<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/src/Support/CodeInjection.php
+++ b/src/Support/CodeInjection.php
@@ -11,7 +11,8 @@ class CodeInjection
     {
         $contents = File::get($file);
 
-        $lines = explode("\n", $contents);
+        $lineEnding = Str::contains($contents, "\r\n") ? "\r\n" : "\n";
+        $lines = explode($lineEnding, $contents);
 
         $useLines = array_filter($lines, fn ($line) => Str::startsWith($line, 'use '));
         $originalUseLines = $useLines;
@@ -33,7 +34,7 @@ class CodeInjection
         $lastUseLine = array_key_last($originalUseLines);
 
         // Replace everything in between the first and last "use " lines with the new imports.
-        $contents = implode("\n", array_merge(
+        $contents = implode($lineEnding, array_merge(
             array_slice($lines, 0, $firstUseLine),
             $useLines,
             array_slice($lines, $lastUseLine + 1)

--- a/src/Support/CodeInjection.php
+++ b/src/Support/CodeInjection.php
@@ -16,8 +16,10 @@ class CodeInjection
         $useLines = array_filter($lines, fn ($line) => Str::startsWith($line, 'use '));
         $originalUseLines = $useLines;
 
-        foreach ($imports as $import) {
-            $useLines[] = "use $import;";
+        foreach ($imports as $class => $alias) {
+            $useLines[] = is_string($class)
+                ? "use $class as $alias;"
+                : "use $alias;";
         }
 
         // Filter out duplicate imports.

--- a/tests/Commands/InstallCommandTest.php
+++ b/tests/Commands/InstallCommandTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Commands;
+
+use DuncanMcClean\Cargo\Support\CodeInjection;
+use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class InstallCommandTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    private const MAILABLES = [
+        'OrderConfirmation' => 'order-confirmation',
+        'OrderShipped' => 'order-shipped',
+    ];
+
+    private string $basePath;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $this->basePath = __DIR__.'/__fixtures__/install';
+
+        File::deleteDirectory($this->basePath);
+        File::copyDirectory(__DIR__.'/__fixtures__/app', $this->basePath);
+
+        $app->useStoragePath($app->storagePath());
+        $app->setBasePath($this->basePath);
+        $app['config']->set('statamic.cargo.taxes.tax_classes.path', $this->basePath.'/content/cargo/tax-classes.yaml');
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->basePath);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    #[DataProvider('existingMailablesProvider')]
+    public function it_publishes_missing_mailables(array $existingMailables)
+    {
+        foreach ($existingMailables as $mailable) {
+            $this->publishCustomisedMailable($mailable);
+        }
+
+        $this->runInstallCommand();
+
+        foreach (self::MAILABLES as $mailable => $view) {
+            in_array($mailable, $existingMailables)
+                ? $this->assertMailableUntouched($mailable, $view)
+                : $this->assertMailablePublished($mailable, $view);
+        }
+
+        $appServiceProvider = File::get(app_path('Providers/AppServiceProvider.php'));
+
+        $this->assertStringContainsString('use App\Mail\OrderConfirmation;', $appServiceProvider);
+        $this->assertStringContainsString('use App\Mail\OrderShipped;', $appServiceProvider);
+        $this->assertStringContainsString('use DuncanMcClean\Cargo\Events\OrderPaymentReceived;', $appServiceProvider);
+        $this->assertStringContainsString('use DuncanMcClean\Cargo\Events\OrderShipped as OrderShippedEvent;', $appServiceProvider);
+        $this->assertEquals(1, substr_count($appServiceProvider, 'Event::listen(OrderPaymentReceived::class'));
+        $this->assertEquals(1, substr_count($appServiceProvider, 'Event::listen(OrderShippedEvent::class'));
+        $this->assertEquals(1, substr_count($appServiceProvider, 'new OrderConfirmation($event->order)'));
+        $this->assertEquals(1, substr_count($appServiceProvider, 'new OrderShipped($event->order)'));
+    }
+
+    public static function existingMailablesProvider(): array
+    {
+        return [
+            'fresh install' => [[]],
+            'order confirmation mailable already published' => [['OrderConfirmation']],
+            'both mailables already published' => [['OrderConfirmation', 'OrderShipped']],
+        ];
+    }
+
+    private function publishCustomisedMailable(string $mailable): void
+    {
+        $view = self::MAILABLES[$mailable];
+
+        File::ensureDirectoryExists(app_path('Mail'));
+        File::put(app_path("Mail/{$mailable}.php"), "<?php // customised {$mailable} mailable");
+
+        File::ensureDirectoryExists(resource_path('views/emails'));
+        File::put(resource_path("views/emails/{$view}.blade.php"), "customised {$view} view");
+
+        $event = match ($mailable) {
+            'OrderConfirmation' => 'OrderPaymentReceived',
+            'OrderShipped' => 'OrderShippedEvent',
+        };
+
+        CodeInjection::injectImports(
+            file: app_path('Providers/AppServiceProvider.php'),
+            imports: [
+                'Illuminate\Support\Facades\Event',
+                'Illuminate\Support\Facades\Mail',
+                "App\Mail\\{$mailable}",
+                match ($mailable) {
+                    'OrderConfirmation' => 'DuncanMcClean\Cargo\Events\OrderPaymentReceived',
+                    'OrderShipped' => 'DuncanMcClean\Cargo\Events\OrderShipped as OrderShippedEvent',
+                },
+            ],
+        );
+
+        CodeInjection::injectIntoAppServiceProviderBoot(<<<PHP
+    Event::listen({$event}::class, function (\$event) {
+            Mail::to(\$event->order->customer())
+                ->locale(\$event->order->site()->shortLocale())
+                ->send(new {$mailable}(\$event->order));
+        });
+PHP);
+    }
+
+    private function runInstallCommand(): void
+    {
+        $this->artisan('statamic:cargo:install')
+            ->expectsQuestion('Which currency do you want to use?', 'GBP')
+            ->expectsQuestion('Which currency do you want to use?', 'GBP')
+            ->expectsQuestion('Which collection contains your products?', 'new')
+            ->expectsQuestion('What should the collection be called?', 'Products')
+            ->expectsConfirmation('Would you like to ignore the carts directory from Git?', 'no')
+            ->expectsConfirmation('Would you like to ignore the orders directory from Git?', 'no')
+            ->expectsConfirmation('Would you like to publish the pre-built checkout flow?', 'no')
+            ->assertSuccessful();
+    }
+
+    private function assertMailablePublished(string $mailable, string $view): void
+    {
+        $this->assertFileEquals(
+            __DIR__."/../../src/Commands/stubs/install/{$mailable}.php.stub",
+            app_path("Mail/{$mailable}.php"),
+        );
+
+        $this->assertFileEquals(
+            __DIR__."/../../src/Commands/stubs/install/{$view}.blade.php.stub",
+            resource_path("views/emails/{$view}.blade.php"),
+        );
+    }
+
+    private function assertMailableUntouched(string $mailable, string $view): void
+    {
+        $this->assertStringEqualsFile(app_path("Mail/{$mailable}.php"), "<?php // customised {$mailable} mailable");
+        $this->assertStringEqualsFile(resource_path("views/emails/{$view}.blade.php"), "customised {$view} view");
+    }
+}

--- a/tests/Commands/__fixtures__/app/app/Providers/AppServiceProvider.php
+++ b/tests/Commands/__fixtures__/app/app/Providers/AppServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/tests/Commands/__fixtures__/app/config/statamic/cp.php
+++ b/tests/Commands/__fixtures__/app/config/statamic/cp.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'widgets' => [
+        //
+    ],
+
+];

--- a/tests/Commands/__fixtures__/app/routes/console.php
+++ b/tests/Commands/__fixtures__/app/routes/console.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Facades\Artisan;
+
+Artisan::command('inspire', function () {
+    $this->comment(Inspiring::quote());
+})->purpose('Display an inspiring quote');

--- a/tests/Commands/__fixtures__/app/routes/web.php
+++ b/tests/Commands/__fixtures__/app/routes/web.php
@@ -1,0 +1,5 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::statamic('home', 'home');

--- a/tests/Support/CodeInjectionTest.php
+++ b/tests/Support/CodeInjectionTest.php
@@ -76,6 +76,23 @@ PHP, File::get($this->file));
     }
 
     #[Test]
+    public function it_preserves_windows_line_endings()
+    {
+        File::put($this->file, str_replace("\n", "\r\n", File::get($this->file)));
+
+        CodeInjection::injectImports($this->file, [
+            'Illuminate\Support\Facades\Event',
+            'Illuminate\Support\Facades\Mail',
+        ]);
+
+        $contents = File::get($this->file);
+
+        $this->assertStringContainsString("use Illuminate\\Support\\Facades\\Event;\r\nuse Illuminate\\Support\\Facades\\Mail;\r\nuse Illuminate\\Support\\ServiceProvider;\r\n", $contents);
+        $this->assertStringNotContainsString("\r\r", $contents);
+        $this->assertEquals(0, substr_count(str_replace("\r\n", '', $contents), "\n"));
+    }
+
+    #[Test]
     public function it_does_not_duplicate_existing_imports()
     {
         CodeInjection::injectImports($this->file, [

--- a/tests/Support/CodeInjectionTest.php
+++ b/tests/Support/CodeInjectionTest.php
@@ -78,7 +78,7 @@ PHP, File::get($this->file));
     #[Test]
     public function it_preserves_windows_line_endings()
     {
-        File::put($this->file, str_replace("\n", "\r\n", File::get($this->file)));
+        File::put($this->file, preg_replace('/\r?\n/', "\r\n", File::get($this->file)));
 
         CodeInjection::injectImports($this->file, [
             'Illuminate\Support\Facades\Event',

--- a/tests/Support/CodeInjectionTest.php
+++ b/tests/Support/CodeInjectionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Support;
+
+use DuncanMcClean\Cargo\Support\CodeInjection;
+use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class CodeInjectionTest extends TestCase
+{
+    private string $file;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->file = __DIR__.'/__fixtures__/AppServiceProvider.php';
+
+        File::ensureDirectoryExists(dirname($this->file));
+        File::put($this->file, <<<'PHP'
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        //
+    }
+}
+PHP);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(dirname($this->file));
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_injects_imports()
+    {
+        CodeInjection::injectImports($this->file, [
+            'Illuminate\Support\Facades\Mail',
+            'App\Mail\OrderConfirmation',
+        ]);
+
+        $this->assertStringContainsString(<<<'PHP'
+use App\Mail\OrderConfirmation;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\ServiceProvider;
+PHP, File::get($this->file));
+    }
+
+    #[Test]
+    public function it_injects_aliased_imports()
+    {
+        CodeInjection::injectImports($this->file, [
+            'App\Mail\OrderShipped',
+            'DuncanMcClean\Cargo\Events\OrderShipped' => 'OrderShippedEvent',
+        ]);
+
+        $this->assertStringContainsString(<<<'PHP'
+use App\Mail\OrderShipped;
+use DuncanMcClean\Cargo\Events\OrderShipped as OrderShippedEvent;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\ServiceProvider;
+PHP, File::get($this->file));
+    }
+
+    #[Test]
+    public function it_does_not_duplicate_existing_imports()
+    {
+        CodeInjection::injectImports($this->file, [
+            'Illuminate\Support\Facades\Event',
+            'Illuminate\Support\ServiceProvider',
+        ]);
+
+        $contents = File::get($this->file);
+
+        $this->assertEquals(1, substr_count($contents, 'use Illuminate\Support\Facades\Event;'));
+        $this->assertEquals(1, substr_count($contents, 'use Illuminate\Support\ServiceProvider;'));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -58,6 +58,7 @@ abstract class TestCase extends AddonTestCase
             OrderServiceProvider::class,
             PaymentServiceProvider::class,
             ShippingServiceProvider::class,
+            \Stillat\Proteus\WriterServiceProvider::class,
         ]);
     }
 


### PR DESCRIPTION
This pull request implements an "order shipped" email, published during `cargo:install` alongside the existing order confirmation email. Shipping notifications are one of the most expected emails from a store, and until now everyone had to build one by hand.

<img width="663" height="661" alt="CleanShot 2026-09-12 at 15 59 51" src="https://github.com/user-attachments/assets/ba7bd2ef-1d5e-44c0-928f-645a196ea390" />


## The mailable

The installer now publishes `App\Mail\OrderShipped` and `resources/views/emails/order-shipped.blade.php`, and registers a listener for Cargo's `OrderShipped` event in your `AppServiceProvider`:

```php
use App\Mail\OrderShipped;
use DuncanMcClean\Cargo\Events\OrderShipped as OrderShippedEvent;

Event::listen(OrderShippedEvent::class, function ($event) {
    Mail::to($event->order->customer())
        ->locale($event->order->site()->shortLocale())
        ->send(new OrderShipped($event->order));
});
```

The email includes the shipping option, the tracking number (when one has been entered against the order), the shipping address and a summary of the line items.

The mailable keeps the `OrderShipped` name to mirror the event and Laravel's own docs, so the event is aliased in the injected code. To support that, `CodeInjection::injectImports()` now accepts `'Fully\Qualified\Class' => 'Alias'` entries.

## Existing installs

Mailables are now published independently of one another. If you installed Cargo before this change, running `php please cargo:install` again will publish the `OrderShipped` mailable and its listener without overwriting your existing `OrderConfirmation` mailable or duplicating its listener. If both mailables already exist, nothing changes.
