### PR TITLE
Support metadata fields on line items

### DIFF
--- a/docs/docs/orders.md
+++ b/docs/docs/orders.md
@@ -11,6 +11,11 @@ If you need to add additional fields to orders, you can do so by updating the Or
 
 The blueprint only contains your custom fields. They'll be merged with Cargo's built-in order blueprint.
 
+### Line Items
+Line items have their own blueprint, also found on the "Blueprints" page. Add fields here for any extra data you store on line items, like engraving text or uploaded artwork.
+
+Any data passed to the [`{{ cart:add }}`](/frontend/tags/cart#adding-to-the-cart) tag or the [JSON API](/frontend/json-api/endpoints#add-a-line-item) is saved on the line item. Data with a matching blueprint field is shown on the order in the Control Panel and on packing slips, using the field's display name and fieldtype.
+
 ## Statuses
 Orders can move between various different statuses:
 * Payment Pending

--- a/docs/extending/events/list.md
+++ b/docs/extending/events/list.md
@@ -98,6 +98,20 @@ public function handle(DiscountSaved $event)
 }
 ```
 
+### LineItemBlueprintFound
+`DuncanMcClean\Cargo\Events\LineItemBlueprintFound`
+
+Dispatched when Cargo gets the [line item blueprint](/docs/orders#line-items).
+
+You may modify the blueprint here, in the same way as `OrderBlueprintFound`.
+
+```php
+public function handle(LineItemBlueprintFound $event)
+{
+	$event->blueprint->ensureField('engraving', ['type' => 'text', 'display' => 'Engraving Text']);
+}
+```
+
 ### OrderBlueprintFound
 `DuncanMcClean\Cargo\Events\OrderBlueprintFound`
 

--- a/resources/js/components/fieldtypes/OrderReceipt/LineItemMetadata.vue
+++ b/resources/js/components/fieldtypes/OrderReceipt/LineItemMetadata.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+    metadata: Array,
+});
+
+const values = computed(() => Object.fromEntries(props.metadata.map((item) => [item.handle, item.value])));
+
+const indexComponent = (item) => Statamic.$app.component(`${item.fieldtype}-fieldtype-index`);
+</script>
+
+<template>
+    <tr class="border-b border-gray-200 dark:border-gray-700">
+        <td colspan="4" class="pb-3">
+            <dl class="-mx-3 grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-x-6 gap-y-3 rounded-lg bg-gray-50 px-3 py-3 dark:bg-gray-900/50">
+                <div v-for="item in metadata" :key="item.handle" class="min-w-0">
+                    <dt class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ item.display }}</dt>
+                    <dd class="mt-1 text-sm text-gray-800 dark:text-gray-200">
+                        <component
+                            v-if="indexComponent(item)"
+                            :is="indexComponent(item)"
+                            :handle="item.handle"
+                            :value="item.value"
+                            :values
+                        />
+                        <span v-else class="whitespace-pre-line break-words" v-text="item.value" />
+                    </dd>
+                </div>
+            </dl>
+        </td>
+    </tr>
+</template>

--- a/resources/js/components/fieldtypes/OrderReceipt/LineItemRow.vue
+++ b/resources/js/components/fieldtypes/OrderReceipt/LineItemRow.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { TableRow, TableCell } from '@statamic/cms/ui';
 import { InlineEditForm } from '@statamic/cms';
+import LineItemMetadata from './LineItemMetadata.vue';
 import { ref } from 'vue';
 
 const emit = defineEmits(['updated']);
@@ -32,7 +33,7 @@ function itemUpdated(responseData) {
 </script>
 
 <template>
-    <TableRow>
+    <TableRow :class="{ 'border-b-0!': lineItem.metadata.length }">
         <TableCell>
             <div
                 v-if="lineItem.product.invalid"
@@ -59,4 +60,6 @@ function itemUpdated(responseData) {
             @closed="isEditing = false"
         />
     </TableRow>
+
+    <LineItemMetadata v-if="lineItem.metadata.length" :metadata="lineItem.metadata" />
 </template>

--- a/resources/views/packing-slip.antlers.html
+++ b/resources/views/packing-slip.antlers.html
@@ -100,7 +100,12 @@
                 {{ order:line_items }}
                     {{ if product:type !== 'digital' }}
                         <tr>
-                            <td class="text-sm">{{ product:title }}</td>
+                            <td class="text-sm">
+                                {{ product:title }}
+                                {{ metadata }}
+                                    <div class="text-xs text-gray-600">{{ display }}: {{ value }}</div>
+                                {{ /metadata }}
+                            </td>
                             <td class="text-sm text-right w-20">{{ quantity }}</td>
                         </tr>
                     {{ /if }}

--- a/src/Events/LineItemBlueprintFound.php
+++ b/src/Events/LineItemBlueprintFound.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Events;
+
+use Statamic\Events\Event;
+
+class LineItemBlueprintFound extends Event
+{
+    public function __construct(public $blueprint) {}
+}

--- a/src/Fieldtypes/OrderReceipt.php
+++ b/src/Fieldtypes/OrderReceipt.php
@@ -5,6 +5,7 @@ namespace DuncanMcClean\Cargo\Fieldtypes;
 use DuncanMcClean\Cargo\Orders\LineItem;
 use DuncanMcClean\Cargo\Orders\LineItems;
 use DuncanMcClean\Cargo\Support\Money;
+use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
 
 class OrderReceipt extends Fieldtype
@@ -36,6 +37,12 @@ class OrderReceipt extends Fieldtype
                 'quantity' => $lineItem->quantity(),
                 'sub_total' => Money::format($lineItem->subTotal(), $order->site()),
                 'total' => Money::format($lineItem->total(), $order->site()),
+                'metadata' => $lineItem->metadata()->map(fn (Field $field) => [
+                    'handle' => $field->handle(),
+                    'display' => $field->display(),
+                    'fieldtype' => $field->type(),
+                    'value' => $field->preProcessIndex()->value(),
+                ])->values()->all(),
             ])->all(),
             'discounts' => collect($order->get('discount_breakdown'))->map(fn ($discount) => [
                 'discount' => $discount['discount'],

--- a/src/Orders/AugmentedLineItem.php
+++ b/src/Orders/AugmentedLineItem.php
@@ -3,6 +3,7 @@
 namespace DuncanMcClean\Cargo\Orders;
 
 use Statamic\Data\AbstractAugmented;
+use Statamic\Fields\Field;
 use Statamic\Fields\Value;
 use Statamic\Support\Str;
 
@@ -28,7 +29,17 @@ class AugmentedLineItem extends AbstractAugmented
         return [
             'id',
             'has_downloads',
+            'metadata',
         ];
+    }
+
+    public function metadata(): array
+    {
+        return $this->data->metadata()->map(fn (Field $field) => [
+            'handle' => $field->handle(),
+            'display' => $field->display(),
+            'value' => $this->get($field->handle()),
+        ])->values()->all();
     }
 
     public function get($handle): Value

--- a/src/Orders/LineItem.php
+++ b/src/Orders/LineItem.php
@@ -5,10 +5,12 @@ namespace DuncanMcClean\Cargo\Orders;
 use DuncanMcClean\Cargo\Contracts\Products\Product as ProductContract;
 use DuncanMcClean\Cargo\Facades\Product;
 use DuncanMcClean\Cargo\Products\ProductVariant;
+use Illuminate\Support\Collection;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Data\ContainsData;
 use Statamic\Data\HasAugmentedInstance;
 use Statamic\Fields\Blueprint as StatamicBlueprint;
+use Statamic\Fields\Field;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class LineItem
@@ -151,6 +153,13 @@ class LineItem
     public function blueprint(): StatamicBlueprint
     {
         return LineItems::blueprint();
+    }
+
+    public function metadata(): Collection
+    {
+        return $this->blueprint()->fields()->all()
+            ->filter(fn (Field $field) => $this->has($field->handle()))
+            ->map(fn (Field $field) => $field->newInstance()->setValue($this->get($field->handle()))->setParent($this));
     }
 
     public function fileData(): array

--- a/src/Orders/LineItemBlueprint.php
+++ b/src/Orders/LineItemBlueprint.php
@@ -4,12 +4,13 @@ namespace DuncanMcClean\Cargo\Orders;
 
 use Statamic\Facades\Blueprint as BlueprintFacade;
 use Statamic\Fields\Blueprint as StatamicBlueprint;
+use Statamic\Fields\Field;
 
 class LineItemBlueprint
 {
     public function __invoke(): StatamicBlueprint
     {
-        return BlueprintFacade::makeFromFields([
+        $blueprint = BlueprintFacade::makeFromFields([
             'product' => ['type' => 'entries', 'max_items' => 1, 'collections' => config('statamic.cargo.products.collections')],
             'variant' => ['type' => 'text'],
             'quantity' => ['type' => 'integer'],
@@ -19,5 +20,11 @@ class LineItemBlueprint
             'discount_total' => ['type' => 'money', 'save_zero_value' => true],
             'total' => ['type' => 'money', 'save_zero_value' => true],
         ])->setHandle('line_item');
+
+        BlueprintFacade::find('cargo::line_item')?->fields()->all()
+            ->reject(fn (Field $field) => $blueprint->hasField($field->handle()))
+            ->each(fn (Field $field) => $blueprint->ensureField($field->handle(), $field->config()));
+
+        return $blueprint;
     }
 }

--- a/src/Orders/LineItems.php
+++ b/src/Orders/LineItems.php
@@ -2,6 +2,7 @@
 
 namespace DuncanMcClean\Cargo\Orders;
 
+use DuncanMcClean\Cargo\Events\LineItemBlueprintFound;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Statamic\Facades\Stache;
@@ -77,6 +78,10 @@ class LineItems extends Collection
 
     public static function blueprint()
     {
-        return (new LineItemBlueprint)();
+        $blueprint = (new LineItemBlueprint)();
+
+        LineItemBlueprintFound::dispatch($blueprint);
+
+        return $blueprint;
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -405,7 +405,17 @@ class ServiceProvider extends AddonServiceProvider
         Blueprint::addNamespace('cargo', __DIR__.'/../resources/blueprints');
 
         if (! Blueprint::find('cargo::order')) {
-            Blueprint::make('order')->setNamespace('cargo')->save();
+            Blueprint::make('order')
+                ->setNamespace('cargo')
+                ->setContents(['title' => __('Order')])
+                ->save();
+        }
+
+        if (! Blueprint::find('cargo::line_item')) {
+            Blueprint::make('line_item')
+                ->setNamespace('cargo')
+                ->setContents(['title' => __('Line Item')])
+                ->save();
         }
 
         return $this;

--- a/tests/Orders/LineItemTest.php
+++ b/tests/Orders/LineItemTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Orders;
+
+use DuncanMcClean\Cargo\Events\LineItemBlueprintFound;
+use DuncanMcClean\Cargo\Facades\Order;
+use DuncanMcClean\Cargo\Orders\LineItems;
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class LineItemTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Collection::make('products')->save();
+        Entry::make()->id('product-id')->collection('products')->data(['title' => 'T-shirt', 'price' => 1500])->save();
+    }
+
+    #[Test]
+    public function blueprint_includes_fields_from_custom_blueprint()
+    {
+        $customBlueprint = Blueprint::make('line_item')->setNamespace('cargo')->setContents([
+            'tabs' => ['main' => ['sections' => [['fields' => [
+                ['handle' => 'engraving', 'field' => ['type' => 'text', 'display' => 'Engraving Text']],
+                ['handle' => 'quantity', 'field' => ['type' => 'text']],
+            ]]]]],
+        ]);
+
+        Blueprint::partialMock()->shouldReceive('find')->with('cargo::line_item')->andReturn($customBlueprint);
+
+        $blueprint = LineItems::blueprint();
+
+        $this->assertEquals('Engraving Text', $blueprint->field('engraving')->display());
+        $this->assertEquals('integer', $blueprint->field('quantity')->type());
+    }
+
+    #[Test]
+    public function blueprint_can_be_extended_with_an_event()
+    {
+        Event::listen(LineItemBlueprintFound::class, function (LineItemBlueprintFound $event) {
+            $event->blueprint->ensureField('engraving', ['type' => 'text']);
+        });
+
+        $this->assertTrue(LineItems::blueprint()->hasField('engraving'));
+    }
+
+    #[Test]
+    public function metadata_only_includes_blueprint_fields_with_a_value()
+    {
+        Event::listen(LineItemBlueprintFound::class, function (LineItemBlueprintFound $event) {
+            $event->blueprint->ensureField('engraving', ['type' => 'text', 'display' => 'Engraving Text']);
+            $event->blueprint->ensureField('gift_wrap', ['type' => 'toggle']);
+        });
+
+        $lineItem = Order::make()->lineItems([
+            ['product' => 'product-id', 'quantity' => 1, 'unit_price' => 1500, 'engraving' => 'Happy Birthday', 'gift_message' => 'Enjoy!', 'tax_breakdown' => []],
+        ])->lineItems()->first();
+
+        $metadata = $lineItem->metadata();
+
+        $this->assertEquals(['engraving'], $metadata->keys()->all());
+        $this->assertEquals('Engraving Text', $metadata->get('engraving')->display());
+        $this->assertEquals('Happy Birthday', $metadata->get('engraving')->value());
+    }
+
+    #[Test]
+    public function metadata_is_augmented()
+    {
+        Event::listen(LineItemBlueprintFound::class, function (LineItemBlueprintFound $event) {
+            $event->blueprint->ensureField('engraving', ['type' => 'text', 'display' => 'Engraving Text']);
+            $event->blueprint->ensureField('gift_wrap', ['type' => 'toggle', 'display' => 'Gift Wrap']);
+        });
+
+        $lineItem = Order::make()->lineItems([
+            ['product' => 'product-id', 'quantity' => 1, 'unit_price' => 1500, 'engraving' => 'Happy Birthday', 'gift_wrap' => true],
+        ])->lineItems()->first();
+
+        $metadata = $lineItem->augmentedValue('metadata')->value();
+
+        $this->assertCount(2, $metadata);
+        $this->assertEquals('Engraving Text', $metadata[0]['display']);
+        $this->assertEquals('Happy Birthday', $metadata[0]['value']->value());
+        $this->assertEquals('Gift Wrap', $metadata[1]['display']);
+        $this->assertTrue($metadata[1]['value']->value());
+    }
+}


### PR DESCRIPTION
This pull request adds support for defining "metadata" fields for line items on carts and orders.

Line items could already carry extra data beyond the product/variant/quantity: anything passed to `{{ cart:add }}`, `{{ cart:update_line_item }}` or the JSON API is saved on the line item. 

This PR makes it so that metadata is visible in the Control Panel when viewing orders.

<img width="1025" height="567" alt="CleanShot 2026-09-12 at 20 05 42" src="https://github.com/user-attachments/assets/485fdd6a-e38f-4067-b7ab-909b37786061" />

To facilitate this, line items now have their own blueprint in the CP, allowing you define the data you want to store and display.