### PR TITLE
Add "Free Shipping" discount type

### DIFF
--- a/docs/docs/carts.md
+++ b/docs/docs/carts.md
@@ -150,8 +150,8 @@ class Calculator
             ->through([  
                 ResetTotals::class,  
                 CalculateLineItems::class,  
-                ApplyCouponDiscounts::class,  
                 ApplyShipping::class,  
+                ApplyDiscounts::class,  
                 CalculateTaxes::class,  
 
 				// Your custom calculator...

--- a/docs/docs/discounts.md
+++ b/docs/docs/discounts.md
@@ -22,7 +22,11 @@ Discounts can be configured using various conditions and limitations. Most of th
 
 ![Discount Create Form](/images/discount-publish-form.png)
 
-Cargo supports "Amount off" and "Percentage off" discount types out-of-the-box, with more on the way. If you need to, you can also [build your own discount type](#building-your-own-discount-type).
+Cargo supports three discount types out-of-the-box. If you need to, you can also [build your own discount type](#building-your-own-discount-type).
+
+* **Amount off**: takes a fixed amount off the cart, split proportionally across the eligible line items.
+* **Percentage off**: takes a percentage off each eligible line item.
+* **Free Shipping**: removes the cost of the customer's selected shipping option. When the discount is limited to specific products, the cart only needs to contain one of them. It won't do anything until the customer has selected a shipping option, and no tax will be charged on the discounted shipping.
 
 ## Redeem discount codes
 You can redeem discount codes using the `{{ cart:update }}` form. Simply provide a `discount_code` input so the customer can enter their discount code.
@@ -117,5 +121,7 @@ class AmountOff extends DiscountType
 ```
 
 As you might expect, the `calculate` method should calculate the discount amount for a line item, returning it as an integer (in pence).
+
+If your discount type should also discount shipping, override the `calculateShipping` method. It receives the cart and should return the amount to take off the shipping total, again as an integer (in pence).
 
 The `fieldItems` method allows you to define any config fields for the discount type. You can then access them using `$this->discount->get('field_handle')`.

--- a/src/Cart/Calculator/ApplyDiscounts.php
+++ b/src/Cart/Calculator/ApplyDiscounts.php
@@ -42,10 +42,19 @@ class ApplyDiscounts
                     return;
                 }
 
+                $shippingAmount = min($discount->discountType()->calculateShipping($cart), $cart->shippingTotal());
+                $cart->shippingTotal($cart->shippingTotal() - $shippingAmount);
+
+                $amount = $lineItems->sum() + $shippingAmount;
+
+                if ($amount === 0) {
+                    return;
+                }
+
                 return (array) DiscountCalculation::make(
                     discount: $discount->handle(),
                     description: $discount->get('discount_code') ?? $discount->title(),
-                    amount: $lineItems->sum(),
+                    amount: $amount,
                 );
             })
             ->filter();

--- a/src/Cart/Calculator/CalculateTotals.php
+++ b/src/Cart/Calculator/CalculateTotals.php
@@ -18,8 +18,10 @@ class CalculateTotals
             $total += $cart->lineItems()->map->taxTotal()->sum();
         }
 
-        // Apply any discounts to the total before adding shipping.
-        $total = $total - $cart->discountTotal();
+        // Apply any line item discounts to the total before adding shipping.
+        // Shipping discounts are already reflected in the shipping total,
+        // so we don't need to do anything about them here.
+        $total = $total - $cart->lineItems()->map->discountTotal()->sum();
 
         // Add shipping costs to the total
         $total += $cart->shippingTotal();

--- a/src/Cart/Calculator/Calculator.php
+++ b/src/Cart/Calculator/Calculator.php
@@ -13,8 +13,8 @@ class Calculator
             ->through([
                 ResetTotals::class,
                 CalculateLineItems::class,
-                ApplyDiscounts::class,
                 ApplyShipping::class,
+                ApplyDiscounts::class,
                 CalculateTaxes::class,
                 CalculateTotals::class,
             ])

--- a/src/Discounts/DiscountServiceProvider.php
+++ b/src/Discounts/DiscountServiceProvider.php
@@ -10,6 +10,7 @@ class DiscountServiceProvider extends AddonServiceProvider
     protected array $discountTypes = [
         Types\AmountOff::class,
         Types\PercentageOff::class,
+        Types\FreeShipping::class,
     ];
 
     public function bootAddon()

--- a/src/Discounts/Types/DiscountType.php
+++ b/src/Discounts/Types/DiscountType.php
@@ -26,6 +26,11 @@ abstract class DiscountType
 
     abstract public function calculate(Cart $cart, LineItem $lineItem): int;
 
+    public function calculateShipping(Cart $cart): int
+    {
+        return 0;
+    }
+
     public function isValidForLineItem(Cart $cart, LineItem $lineItem): bool
     {
         if ($this->discount->get('start_date') !== null) {

--- a/src/Discounts/Types/FreeShipping.php
+++ b/src/Discounts/Types/FreeShipping.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DuncanMcClean\Cargo\Discounts\Types;
+
+use DuncanMcClean\Cargo\Contracts\Cart\Cart;
+use DuncanMcClean\Cargo\Orders\LineItem;
+
+class FreeShipping extends DiscountType
+{
+    protected static $title = 'Free Shipping';
+
+    public function calculate(Cart $cart, LineItem $lineItem): int
+    {
+        return 0;
+    }
+
+    public function calculateShipping(Cart $cart): int
+    {
+        return $cart->shippingTotal();
+    }
+}

--- a/tests/Cart/Calculator/ApplyDiscountsTest.php
+++ b/tests/Cart/Calculator/ApplyDiscountsTest.php
@@ -121,6 +121,69 @@ class ApplyDiscountsTest extends TestCase
         $this->assertEquals(2500, $cart->lineItems()->find('abc')->discountTotal());
     }
 
+    #[Test]
+    public function applies_free_shipping_discount_to_shipping_total()
+    {
+        $this->makeProduct('123')->set('price', 2500)->save();
+
+        Discount::make()->handle('a')->title('Discount A')->type('percentage_off')->set('percentage_off', 10)->save();
+        Discount::make()->handle('b')->title('Free Shipping')->type('free_shipping')->save();
+
+        $cart = Cart::make()->shippingTotal(500)->lineItems([
+            ['id' => 'abc', 'product' => '123', 'quantity' => 1, 'total' => 2500],
+        ]);
+
+        $cart = app(ApplyDiscounts::class)->handle($cart, fn ($cart) => $cart);
+
+        $this->assertEquals([
+            ['discount' => 'a', 'description' => 'Discount A', 'amount' => 250],
+            ['discount' => 'b', 'description' => 'Free Shipping', 'amount' => 500],
+        ], $cart->get('discount_breakdown'));
+
+        $this->assertEquals(750, $cart->discountTotal());
+        $this->assertEquals(0, $cart->shippingTotal());
+        $this->assertEquals(250, $cart->lineItems()->find('abc')->discountTotal());
+    }
+
+    #[Test]
+    public function ensures_shipping_discounts_do_not_exceed_shipping_total()
+    {
+        $this->makeProduct('123')->set('price', 2500)->save();
+
+        Discount::make()->handle('a')->title('Free Shipping A')->type('free_shipping')->save();
+        Discount::make()->handle('b')->title('Free Shipping B')->type('free_shipping')->save();
+
+        $cart = Cart::make()->shippingTotal(500)->lineItems([
+            ['id' => 'abc', 'product' => '123', 'quantity' => 1, 'total' => 2500],
+        ]);
+
+        $cart = app(ApplyDiscounts::class)->handle($cart, fn ($cart) => $cart);
+
+        $this->assertEquals([
+            ['discount' => 'a', 'description' => 'Free Shipping A', 'amount' => 500],
+        ], $cart->get('discount_breakdown'));
+
+        $this->assertEquals(500, $cart->discountTotal());
+        $this->assertEquals(0, $cart->shippingTotal());
+    }
+
+    #[Test]
+    public function discounts_which_do_not_discount_anything_are_not_applied()
+    {
+        $this->makeProduct('123')->set('price', 2500)->save();
+
+        Discount::make()->handle('a')->title('Free Shipping')->type('free_shipping')->save();
+
+        $cart = Cart::make()->lineItems([
+            ['id' => 'abc', 'product' => '123', 'quantity' => 1, 'total' => 2500],
+        ]);
+
+        $cart = app(ApplyDiscounts::class)->handle($cart, fn ($cart) => $cart);
+
+        $this->assertNull($cart->get('discount_breakdown'));
+        $this->assertEquals(0, $cart->discountTotal());
+    }
+
     protected function makeProduct($id = null)
     {
         Collection::make('products')->save();

--- a/tests/Cart/Calculator/CalculateTotalsTest.php
+++ b/tests/Cart/Calculator/CalculateTotalsTest.php
@@ -75,7 +75,35 @@ class CalculateTotalsTest extends TestCase
     }
 
     #[Test]
-    public function discount_total_is_subtracted_from_grand_total()
+    public function line_item_discounts_are_subtracted_from_grand_total()
+    {
+        config()->set('statamic.cargo.taxes.price_includes_tax', true);
+
+        $cart = Cart::make()
+            ->lineItems([
+                [
+                    'product' => 'product-id',
+                    'quantity' => 1,
+                    'unit_price' => 500,
+                    'sub_total' => 500,
+                    'tax_total' => 20,
+                    'discount_total' => 400,
+                    'total' => 500,
+                ],
+            ])
+            ->subTotal(500)
+            ->shippingTotal(500)
+            ->set('shipping_tax_total', 20)
+            ->taxTotal(40)
+            ->discountTotal(400);
+
+        $cart = app(CalculateTotals::class)->handle($cart, fn ($cart) => $cart);
+
+        $this->assertEquals(600, $cart->grandTotal());
+    }
+
+    #[Test]
+    public function shipping_discounts_are_not_subtracted_from_grand_total_again()
     {
         config()->set('statamic.cargo.taxes.price_includes_tax', true);
 
@@ -91,13 +119,12 @@ class CalculateTotalsTest extends TestCase
                 ],
             ])
             ->subTotal(500)
-            ->shippingTotal(500)
-            ->set('shipping_tax_total', 20)
-            ->taxTotal(40)
-            ->discountTotal(400);
+            ->shippingTotal(0)
+            ->taxTotal(20)
+            ->discountTotal(500);
 
         $cart = app(CalculateTotals::class)->handle($cart, fn ($cart) => $cart);
 
-        $this->assertEquals(600, $cart->grandTotal());
+        $this->assertEquals(500, $cart->grandTotal());
     }
 }

--- a/tests/Discounts/Types/FreeShippingTest.php
+++ b/tests/Discounts/Types/FreeShippingTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Tests\Discounts\Types;
+
+use DuncanMcClean\Cargo\Cart\Calculator\Calculator;
+use DuncanMcClean\Cargo\Contracts\Discounts\Discount as DiscountContract;
+use DuncanMcClean\Cargo\Facades\Cart;
+use DuncanMcClean\Cargo\Facades\Discount;
+use DuncanMcClean\Cargo\Facades\TaxClass;
+use DuncanMcClean\Cargo\Facades\TaxZone;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\User;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\Fixtures\ShippingMethods\PaidShipping;
+use Tests\TestCase;
+
+class FreeShippingTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        PaidShipping::register();
+
+        config()->set('statamic.cargo.shipping.methods', ['paid_shipping' => []]);
+
+        Collection::make('products')->save();
+        Entry::make()->id('product-id')->collection('products')->data(['price' => 2500, 'tax_class' => 'standard'])->save();
+    }
+
+    #[Test]
+    public function it_discounts_shipping_when_a_shipping_option_is_selected()
+    {
+        Discount::make()->handle('free-shipping')->title('Free Shipping')->type('free_shipping')->save();
+
+        $cart = Cart::make()
+            ->lineItems([['id' => 'abc', 'product' => 'product-id', 'quantity' => 1]])
+            ->data(['shipping_method' => 'paid_shipping', 'shipping_option' => 'the_only_option']);
+
+        $cart = Calculator::calculate($cart);
+
+        $this->assertEquals([
+            ['discount' => 'free-shipping', 'description' => 'Free Shipping', 'amount' => 500],
+        ], $cart->get('discount_breakdown'));
+
+        $this->assertEquals(0, $cart->shippingTotal());
+        $this->assertEquals(500, $cart->discountTotal());
+        $this->assertEquals(2500, $cart->grandTotal());
+    }
+
+    #[Test]
+    public function it_does_nothing_until_a_shipping_option_is_selected()
+    {
+        Discount::make()->handle('free-shipping')->title('Free Shipping')->type('free_shipping')->save();
+
+        $cart = Cart::make()->lineItems([['id' => 'abc', 'product' => 'product-id', 'quantity' => 1]]);
+
+        $cart = Calculator::calculate($cart);
+
+        $this->assertNull($cart->get('discount_breakdown'));
+        $this->assertEquals(0, $cart->shippingTotal());
+        $this->assertEquals(0, $cart->discountTotal());
+        $this->assertEquals(2500, $cart->grandTotal());
+    }
+
+    #[Test]
+    #[DataProvider('unmetConditionsProvider')]
+    public function it_does_nothing_when_conditions_are_not_met(callable $configureDiscount)
+    {
+        $configureDiscount(Discount::make()->handle('free-shipping')->title('Free Shipping')->type('free_shipping'))->save();
+
+        $cart = Cart::make()
+            ->customer(tap(User::make()->id('jane')->email('jane@example.com'))->save())
+            ->lineItems([['id' => 'abc', 'product' => 'product-id', 'quantity' => 1]])
+            ->data(['shipping_method' => 'paid_shipping', 'shipping_option' => 'the_only_option']);
+
+        $cart = Calculator::calculate($cart);
+
+        $this->assertNull($cart->get('discount_breakdown'));
+        $this->assertEquals(500, $cart->shippingTotal());
+        $this->assertEquals(0, $cart->discountTotal());
+        $this->assertEquals(3000, $cart->grandTotal());
+    }
+
+    #[Test]
+    public function it_discounts_shipping_for_an_eligible_customer()
+    {
+        Discount::make()->handle('free-shipping')->title('Free Shipping')->type('free_shipping')->set('customers', ['jane'])->save();
+
+        $cart = Cart::make()
+            ->customer(tap(User::make()->id('jane')->email('jane@example.com'))->save())
+            ->lineItems([['id' => 'abc', 'product' => 'product-id', 'quantity' => 1]])
+            ->data(['shipping_method' => 'paid_shipping', 'shipping_option' => 'the_only_option']);
+
+        $cart = Calculator::calculate($cart);
+
+        $this->assertEquals([
+            ['discount' => 'free-shipping', 'description' => 'Free Shipping', 'amount' => 500],
+        ], $cart->get('discount_breakdown'));
+
+        $this->assertEquals(0, $cart->shippingTotal());
+        $this->assertEquals(2500, $cart->grandTotal());
+    }
+
+    public static function unmetConditionsProvider(): array
+    {
+        return [
+            'start date is in the future' => [fn (DiscountContract $discount) => $discount->set('start_date', now()->addDay()->toDateString())],
+            'end date is in the past' => [fn (DiscountContract $discount) => $discount->set('end_date', now()->subDay()->toDateString())],
+            'minimum order value is not reached' => [fn (DiscountContract $discount) => $discount->set('minimum_order_value', 5000)],
+            'maximum uses have been reached' => [fn (DiscountContract $discount) => $discount->set('maximum_uses', 5)->set('redemptions_count', 5)],
+            'customer is not eligible' => [fn (DiscountContract $discount) => $discount->set('customers', ['john'])],
+            'cart does not contain an eligible product' => [fn (DiscountContract $discount) => $discount->set('products', ['another-product-id'])],
+        ];
+    }
+
+    #[Test]
+    public function it_discounts_shipping_when_the_cart_contains_an_eligible_product()
+    {
+        Entry::make()->id('another-product-id')->collection('products')->data(['price' => 1000])->save();
+
+        Discount::make()->handle('free-shipping')->title('Free Shipping')->type('free_shipping')->set('products', ['another-product-id'])->save();
+
+        $cart = Cart::make()
+            ->lineItems([
+                ['id' => 'abc', 'product' => 'product-id', 'quantity' => 1],
+                ['id' => 'def', 'product' => 'another-product-id', 'quantity' => 1],
+            ])
+            ->data(['shipping_method' => 'paid_shipping', 'shipping_option' => 'the_only_option']);
+
+        $cart = Calculator::calculate($cart);
+
+        $this->assertEquals([
+            ['discount' => 'free-shipping', 'description' => 'Free Shipping', 'amount' => 500],
+        ], $cart->get('discount_breakdown'));
+
+        $this->assertEquals(0, $cart->shippingTotal());
+        $this->assertEquals(3500, $cart->grandTotal());
+    }
+
+    #[Test]
+    public function it_stacks_with_a_percentage_off_discount_code()
+    {
+        Discount::make()->handle('free-shipping')->title('Free Shipping')->type('free_shipping')->save();
+        Discount::make()->handle('ten-off')->title('Ten Off')->set('discount_code', 'TENOFF')->type('percentage_off')->set('percentage_off', 10)->save();
+
+        $cart = Cart::make()
+            ->lineItems([['id' => 'abc', 'product' => 'product-id', 'quantity' => 1]])
+            ->data(['discount_code' => 'TENOFF', 'shipping_method' => 'paid_shipping', 'shipping_option' => 'the_only_option']);
+
+        $cart = Calculator::calculate($cart);
+
+        $this->assertEquals([
+            ['discount' => 'free-shipping', 'description' => 'Free Shipping', 'amount' => 500],
+            ['discount' => 'ten-off', 'description' => 'TENOFF', 'amount' => 250],
+        ], $cart->get('discount_breakdown'));
+
+        $this->assertEquals(0, $cart->shippingTotal());
+        $this->assertEquals(750, $cart->discountTotal());
+        $this->assertEquals(250, $cart->lineItems()->find('abc')->discountTotal());
+        $this->assertEquals(2250, $cart->grandTotal());
+    }
+
+    #[Test]
+    public function it_can_be_redeemed_with_a_discount_code()
+    {
+        Discount::make()->handle('free-shipping')->title('Free Shipping')->set('discount_code', 'FREESHIP')->type('free_shipping')->save();
+
+        $cart = Cart::make()
+            ->lineItems([['id' => 'abc', 'product' => 'product-id', 'quantity' => 1]])
+            ->data(['discount_code' => 'FREESHIP', 'shipping_method' => 'paid_shipping', 'shipping_option' => 'the_only_option']);
+
+        $cart = Calculator::calculate($cart);
+
+        $this->assertEquals([
+            ['discount' => 'free-shipping', 'description' => 'FREESHIP', 'amount' => 500],
+        ], $cart->get('discount_breakdown'));
+
+        $this->assertEquals(0, $cart->shippingTotal());
+        $this->assertEquals(2500, $cart->grandTotal());
+    }
+
+    #[Test]
+    public function it_does_not_charge_tax_on_discounted_shipping()
+    {
+        config()->set('statamic.cargo.taxes', [
+            'price_includes_tax' => false,
+            'shipping_tax_behaviour' => 'tax_class',
+        ]);
+
+        File::delete($path = base_path('content/cargo/tax-zones.yaml'));
+        File::ensureDirectoryExists(Str::beforeLast($path, '/'));
+
+        TaxClass::make()->handle('standard')->set('title', 'Standard')->save();
+
+        TaxZone::make()->handle('uk')->data([
+            'title' => 'United Kingdom',
+            'type' => 'countries',
+            'countries' => ['GBR'],
+            'rates' => ['standard' => 20, 'shipping' => 20],
+        ])->save();
+
+        Discount::make()->handle('free-shipping')->title('Free Shipping')->type('free_shipping')->save();
+
+        $cart = Cart::make()
+            ->lineItems([['id' => 'abc', 'product' => 'product-id', 'quantity' => 1]])
+            ->data([
+                'shipping_method' => 'paid_shipping',
+                'shipping_option' => 'the_only_option',
+                'shipping_address' => ['line_1' => '123 Fake St', 'city' => 'Fakeville', 'postcode' => 'FA 1234', 'country' => 'GBR'],
+            ]);
+
+        $cart = Calculator::calculate($cart);
+
+        $this->assertEquals(0, $cart->shippingTotal());
+        $this->assertEquals(0, $cart->get('shipping_tax_total'));
+        $this->assertEquals(500, $cart->taxTotal());
+        $this->assertEquals(500, $cart->discountTotal());
+        $this->assertEquals(3000, $cart->grandTotal());
+    }
+}


### PR DESCRIPTION
This pull request adds a "Free Shipping" discount type, which removes the cost of the customer's selected shipping option.

It works with the same conditions as the other discount types (dates, minimum order value, maximum uses, customers). When the discount is limited to specific products, the cart only needs to contain one of them. It can be automatic or redeemed with a discount code, and stacks with an "Amount off" / "Percentage off" discount on the line items.

## How it's applied

Shipping is now calculated _before_ discounts are applied, so `ApplyShipping` runs ahead of `ApplyDiscounts` in the calculator pipeline. When a free shipping discount applies, the cart's shipping total is set to `0` and the saving is recorded in the `discount_breakdown` (and included in `discount_total`), so it shows up in the checkout summary and CP receipt like any other discount.

Since the shipping total is zeroed before `CalculateTaxes` runs, no tax is charged on the discounted shipping.

The discount does nothing until the customer has selected a shipping option. Discounts which don't end up discounting anything are no longer added to the breakdown.

## Discounting shipping from custom discount types

Discount types can now override the `calculateShipping` method to take an amount off the shipping total:

```php
public function calculateShipping(Cart $cart): int
{
    return $cart->shippingTotal();
}
```

It's called after `calculate()` for each line item, and the amount is capped at the remaining shipping total.

## Behaviour changes

* `ApplyShipping` now runs before `ApplyDiscounts`. Custom shipping methods which read the cart's discount total in `options()` will now see `0`.
* `CalculateTotals` subtracts the line item discount totals, rather than the cart's `discount_total`, since shipping discounts are already reflected in the shipping total.
* Discounts with an amount of `0` are no longer added to the `discount_breakdown`.
