### PR TITLE
Always make Tax Classes available, regardless of tax driver

### DIFF
--- a/docs/docs/taxes.md
+++ b/docs/docs/taxes.md
@@ -214,5 +214,5 @@ public function boot(): void
 ```
 
 :::tip note
-The "Tax Class" and "Tax Zone" features will be unavailable unless your custom tax driver extends Cargo's `DefaultTaxDriver` class.
+Tax Zones are only available when using Cargo's default tax driver. Tax Classes are always available, so your driver can use the product's tax class to decide how it should be taxed (for example, mapping it to a third-party service's product tax codes).
 :::

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -16,8 +16,9 @@ Route::name('cargo.')->group(function () {
     Route::resource('discounts', DiscountController::class)->except(['show', 'destroy']);
     Route::resource('orders', OrderController::class)->only(['index', 'edit', 'update']);
 
+    Route::resource('tax-classes', TaxClassController::class)->except('show');
+
     if (Cargo::usingDefaultTaxDriver()) {
-        Route::resource('tax-classes', TaxClassController::class)->except('show');
         Route::resource('tax-zones', TaxZoneController::class)->except('show');
     }
 

--- a/src/Listeners/EnsureProductFields.php
+++ b/src/Listeners/EnsureProductFields.php
@@ -2,7 +2,6 @@
 
 namespace DuncanMcClean\Cargo\Listeners;
 
-use DuncanMcClean\Cargo\Cargo;
 use Statamic\Events\EntryBlueprintFound;
 use Statamic\Facades\AssetContainer;
 use Statamic\Fields\Blueprint;
@@ -27,7 +26,7 @@ class EnsureProductFields
             ], 'sidebar');
         }
 
-        if (Cargo::usingDefaultTaxDriver() && ! $event->blueprint->hasField('tax_class')) {
+        if (! $event->blueprint->hasField('tax_class')) {
             $event->blueprint->ensureField('tax_class', [
                 'type' => 'tax_classes',
                 'display' => __('Tax Class'),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -257,13 +257,13 @@ class ServiceProvider extends AddonServiceProvider
                 ->icon('shopping-store-discount-percent')
                 ->can('view discounts');
 
-            if (Cargo::usingDefaultTaxDriver()) {
-                $nav->create(__('Tax Classes'))
-                    ->section('Store')
-                    ->route('cargo.tax-classes.index')
-                    ->icon(Cargo::svg('tax-classes'))
-                    ->can('manage taxes');
+            $nav->create(__('Tax Classes'))
+                ->section('Store')
+                ->route('cargo.tax-classes.index')
+                ->icon(Cargo::svg('tax-classes'))
+                ->can('manage taxes');
 
+            if (Cargo::usingDefaultTaxDriver()) {
                 $nav->create(__('Tax Zones'))
                     ->section('Store')
                     ->route('cargo.tax-zones.index')
@@ -299,9 +299,7 @@ class ServiceProvider extends AddonServiceProvider
                     ]);
                 });
 
-                if (Cargo::usingDefaultTaxDriver()) {
-                    Permission::register('manage taxes')->label(__('Manage Taxes'));
-                }
+                Permission::register('manage taxes')->label(__('Manage Taxes'));
             });
         });
 

--- a/tests/Taxes/CustomTaxDriverTest.php
+++ b/tests/Taxes/CustomTaxDriverTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Taxes;
+
+use DuncanMcClean\Cargo\Contracts\Purchasable;
+use DuncanMcClean\Cargo\Contracts\Taxes\Driver;
+use DuncanMcClean\Cargo\Data\Address;
+use DuncanMcClean\Cargo\Orders\LineItem;
+use Illuminate\Support\Collection as SupportCollection;
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\User;
+use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class CustomTaxDriverTest extends TestCase
+{
+    use PreventsSavingStacheItemsToDisk;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->bind(Driver::class, fn () => new class implements Driver
+        {
+            public function setAddress(Address $address): self
+            {
+                return $this;
+            }
+
+            public function setPurchasable(Purchasable $purchasable): self
+            {
+                return $this;
+            }
+
+            public function setLineItem(LineItem $lineItem): self
+            {
+                return $this;
+            }
+
+            public function getBreakdown(int $total): SupportCollection
+            {
+                return collect();
+            }
+        });
+    }
+
+    #[Test]
+    public function tax_classes_are_available()
+    {
+        $this
+            ->actingAs(User::make()->makeSuper()->save())
+            ->get(cp_route('cargo.tax-classes.index'))
+            ->assertOk()
+            ->assertSee('Tax Classes');
+    }
+
+    #[Test]
+    public function tax_class_field_is_added_to_product_blueprint()
+    {
+        Collection::make('products')->save();
+
+        $blueprint = Entry::make()->collection('products')->blueprint();
+
+        $this->assertTrue($blueprint->hasField('tax_class'));
+    }
+
+    #[Test]
+    public function tax_zones_are_unavailable()
+    {
+        $this->assertFalse(Route::has('statamic.cp.cargo.tax-zones.index'));
+    }
+}


### PR DESCRIPTION
This pull request makes Tax Classes available regardless of which tax driver is being used.

Previously, the Tax Classes pages in the Control Panel, the "Manage Taxes" permission and the product's "Tax Class" field were only available when using Cargo's default tax driver. 

However, that meant that custom tax drivers (like those integrating with third-party tax services) would have no way to know _what_ a product is and which tax rates should be applied to what. They'd have to build their own _thing_.

This PR makes Tax Classes always available, so custom drivers can map a product's tax class onto whatever their tax service needs. Tax Zones remain exclusive to the default tax driver, since rates are the driver's concern.