### PR TITLE
Show shipping before discounts in order summaries

### DIFF
--- a/resources/js/components/fieldtypes/OrderReceiptFieldtype.vue
+++ b/resources/js/components/fieldtypes/OrderReceiptFieldtype.vue
@@ -46,15 +46,6 @@ function lineItemUpdated(lineItem) {
                     <TableCell class="font-medium">{{ __('Subtotal') }}</TableCell>
                     <TableCell class="text-right">{{ value.totals.sub_total }}</TableCell>
                 </TableRow>
-                <TableRow v-for="discount in value.discounts">
-                    <TableCell />
-                    <TableCell />
-                    <TableCell>
-                        <strong class="mb-1 block font-medium">{{ __('Discount') }}</strong>
-                        <Description :text="discount.description" />
-                    </TableCell>
-                    <TableCell class="text-right">-{{ discount.amount }}</TableCell>
-                </TableRow>
                 <TableRow v-if="value.shipping">
                     <TableCell />
                     <TableCell />
@@ -63,6 +54,15 @@ function lineItemUpdated(lineItem) {
                         <Description :text="value.shipping.name" />
                     </TableCell>
                     <TableCell class="text-right">{{ value.shipping.price }}</TableCell>
+                </TableRow>
+                <TableRow v-for="discount in value.discounts">
+                    <TableCell />
+                    <TableCell />
+                    <TableCell>
+                        <strong class="mb-1 block font-medium">{{ __('Discount') }}</strong>
+                        <Description :text="discount.description" />
+                    </TableCell>
+                    <TableCell class="text-right">-{{ discount.amount }}</TableCell>
                 </TableRow>
                 <TableRow v-if="value.taxes">
                     <TableCell />

--- a/resources/views/checkout/components/_cart_summary.antlers.html
+++ b/resources/views/checkout/components/_cart_summary.antlers.html
@@ -74,6 +74,25 @@
             <span x-text="cart.sub_total"></span>
         </div>
 
+        {{ if {cart:has_physical_products} }}
+            <div class="flex items-center justify-between">
+                <div class="flex items-center space-x-1">
+                    <span>{{ 'Shipping' | trans }}</span>
+                    <template x-if="cart.shipping_option">
+                        <span class="text-xs text-gray-500" x-text="`(${cart.shipping_option.name})`"></span>
+                    </template>
+                </div>
+
+                <template x-if="cart.shipping_option">
+                    <span x-text="cart.shipping_option.price"></span>
+                </template>
+
+                <template x-if="!cart.shipping_option">
+                    <span class="text-gray-500">{{ 'Enter shipping address' | trans }}</span>
+                </template>
+            </div>
+        {{ /if }}
+
         <template x-if="cart.discounts.length">
             <template x-for="discount in cart.discounts" :key="discount.id">
                 <div class="flex items-center justify-between">
@@ -96,25 +115,6 @@
                 </div>
             </template>
         </template>
-
-        {{ if {cart:has_physical_products} }}
-            <div class="flex items-center justify-between">
-                <div class="flex items-center space-x-1">
-                    <span>{{ 'Shipping' | trans }}</span>
-                    <template x-if="cart.shipping_option">
-                        <span class="text-xs text-gray-500" x-text="`(${cart.shipping_option.name})`"></span>
-                    </template>
-                </div>
-
-                <template x-if="cart.shipping_option">
-                    <span x-text="cart.shipping_option.price"></span>
-                </template>
-
-                <template x-if="!cart.shipping_option">
-                    <span class="text-gray-500">{{ 'Enter shipping address' | trans }}</span>
-                </template>
-            </div>
-        {{ /if }}
 
         {{ if !config:statamic:cargo:taxes:price_includes_tax }}
             <div class="flex items-center justify-between">

--- a/resources/views/checkout/components/_order_summary.antlers.html
+++ b/resources/views/checkout/components/_order_summary.antlers.html
@@ -43,6 +43,16 @@
         <span>{{ sub_total }}</span>
     </div>
 
+    {{ if shipping_option }}
+        <div class="flex items-center justify-between">
+            <div class="flex items-center space-x-1">
+                <span>{{ 'Shipping' | trans }}</span>
+                <span class="text-xs text-gray-500">({{ shipping_option:name }})</span>
+            </div>
+            <span>{{ shipping_option:price }}</span>
+        </div>
+    {{ /if }}
+
     {{ if discounts }}
         {{ discounts }}
             <div class="flex items-center justify-between">
@@ -53,16 +63,6 @@
                 <span>-{{ amount }}</span>
             </div>
         {{ /discounts }}
-    {{ /if }}
-
-    {{ if shipping_option }}
-        <div class="flex items-center justify-between">
-            <div class="flex items-center space-x-1">
-                <span>{{ 'Shipping' | trans }}</span>
-                <span class="text-xs text-gray-500">({{ shipping_option:name }})</span>
-            </div>
-            <span>{{ shipping_option:price }}</span>
-        </div>
     {{ /if }}
 
     {{ if !config:statamic:cargo:taxes:price_includes_tax }}

--- a/src/Commands/stubs/install/order-confirmation.blade.php.stub
+++ b/src/Commands/stubs/install/order-confirmation.blade.php.stub
@@ -22,11 +22,11 @@ $downloadUrl = URL::signedRoute('statamic.cargo.download', [
 |                    |               |
 | -----------------: | ------------: |
 | **Subtotal** | {{ $order->sub_total }} |
-@if($order->discounts)
-| **Discounts** | -{{ $order->discount_total }}|
-@endif
 @if($order->shippingOption)
 | **Shipping** ({{ $order->shippingOption()->name }}) | {{ $order->shipping_total }} |
+@endif
+@if($order->discounts)
+| **Discounts** | -{{ $order->discount_total }}|
 @endif
 @unless(config('statamic.cargo.taxes.price_includes_tax'))
 | **Taxes** | {{ $order->tax_total }} |


### PR DESCRIPTION
This pull request changes the order of the totals rows on the checkout page, confirmation email and when viewing orders in the CP, so that shipping is shown before discounts.

Previously, discounts were listed before shipping. However, with the "Free Shipping" discount type (#281), that meant the "-£5.99" discount line appeared *above* the "£5.99" shipping line it was cancelling out, which read a bit oddly.

Shipping is also now calculated before discounts, so the summaries match the order things are calculated in: Subtotal → Shipping → Discounts → Taxes → Total.

<img width="442" height="425" alt="CleanShot 2026-09-12 at 21 20 00" src="https://github.com/user-attachments/assets/e7c85877-c1a1-4fa1-934b-2cf055e55741" />

